### PR TITLE
Cleanup & include ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    extends: [
+        'semistandard'
+    ],
+    rules: {
+    // enable additional rules
+        indent: ['error', 4]
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,5 @@
 module.exports = {
-    extends: [
-        'semistandard'
-    ],
-    rules: {
-    // enable additional rules
-        indent: ['error', 4]
-    }
+  extends: [
+    'semistandard'
+  ]
 };

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,27 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_GENERATOR_MULT" value="true" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="SPACE_BEFORE_METHOD_PARENTHESES" value="true" />
+      <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/integration-node-library.iml
+++ b/.idea/integration-node-library.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="file://$PROJECT_DIR$" libraries="{Node.js Core}" />
+  </component>
+</project>

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/integration-node-library.iml" filepath="$PROJECT_DIR$/.idea/integration-node-library.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/runConfigurations/light_js.xml
+++ b/.idea/runConfigurations/light_js.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="light.js" type="NodeJSConfigurationType" nameIsGenerated="true" path-to-js-file="light.js" working-dir="$PROJECT_DIR$/examples">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,10 @@ The `icon` needs to be uploaded to the `remote-core` (via the Web Configurator o
 
 ### Running the app
 
-`node light.js`
+```shell
+npm install
+node light.js
+```
 
 ### Registering the integration
 

--- a/examples/light.js
+++ b/examples/light.js
@@ -1,9 +1,9 @@
-"use strict";
+'use strict';
 
 // use package in production
 // const uc = require("uc-integration-api");
-const uc = require("../index");
-uc.init("driver.json");
+const uc = require('../index');
+uc.init('driver.json');
 
 uc.on(uc.EVENTS.CONNECT, async () => {
     await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
@@ -36,18 +36,18 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
 // create a light entity
 // normally you'd create this where your driver exposed the available entities
 const lightEntity = new uc.Entities.Light(
-    "my_unique_light_id",
-    "My favorite light",
+    'my_unique_light_id',
+    'My favorite light',
     uc.getDriverVersion().id,
     [
         uc.Entities.Light.FEATURES.ON_OFF,
-        uc.Entities.Light.FEATURES.DIM,
+        uc.Entities.Light.FEATURES.DIM
     ],
     {
         [uc.Entities.Light.ATTRIBUTES.STATE]: uc.Entities.Light.STATES.OFF,
-        [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS]: 0,
+        [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS]: 0
     }
-)
+);
 
 // add entity as available
 // this is important, so the core knows what entities are available
@@ -67,53 +67,53 @@ uc.on(
         const entity = uc.configuredEntities.getEntity(entity_id);
 
         if (entity == null) {
-            console.log("Entity not found");
+            console.log('Entity not found');
             await uc.acknowledgeCommand(id, uc.STATUS_CODES.NOT_FOUND);
             return;
         }
 
         switch (cmd_id) {
-            case uc.Entities.Light.COMMANDS.TOGGLE:
-                if (entity.attributes.state === uc.Entities.Light.STATES.OFF) {
-                    uc.configuredEntities.updateEntityAttributes(
-                        entity.id,
-                        [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                        [uc.Entities.Light.STATES.ON, 255]
-                    );
-                } else if (entity.attributes.state === uc.Entities.Light.STATES.ON) {
-                    uc.configuredEntities.updateEntityAttributes(
-                        entity.id,
-                        [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                        [uc.Entities.Light.STATES.OFF, 0]
-                    );
-                }
-                break;
-            case uc.Entities.Light.COMMANDS.ON:
-                if (params.brightness) {
-                    uc.configuredEntities.updateEntityAttributes(
-                        entity.id,
-                        [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                        [uc.Entities.Light.STATES.ON, params.brightness]
-                    );
-                } else {
-                    uc.configuredEntities.updateEntityAttributes(
-                        entity.id,
-                        [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                        [uc.Entities.Light.STATES.OFF, 0]
-                    );
-                }
-                break;
-            case uc.Entities.Light.COMMANDS.OFF:
+        case uc.Entities.Light.COMMANDS.TOGGLE:
+            if (entity.attributes.state === uc.Entities.Light.STATES.OFF) {
+                uc.configuredEntities.updateEntityAttributes(
+                    entity.id,
+                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+                    [uc.Entities.Light.STATES.ON, 255]
+                );
+            } else if (entity.attributes.state === uc.Entities.Light.STATES.ON) {
                 uc.configuredEntities.updateEntityAttributes(
                     entity.id,
                     [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
                     [uc.Entities.Light.STATES.OFF, 0]
                 );
-                break;
+            }
+            break;
+        case uc.Entities.Light.COMMANDS.ON:
+            if (params.brightness) {
+                uc.configuredEntities.updateEntityAttributes(
+                    entity.id,
+                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+                    [uc.Entities.Light.STATES.ON, params.brightness]
+                );
+            } else {
+                uc.configuredEntities.updateEntityAttributes(
+                    entity.id,
+                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+                    [uc.Entities.Light.STATES.OFF, 0]
+                );
+            }
+            break;
+        case uc.Entities.Light.COMMANDS.OFF:
+            uc.configuredEntities.updateEntityAttributes(
+                entity.id,
+                [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+                [uc.Entities.Light.STATES.OFF, 0]
+            );
+            break;
         }
 
         // you need to acknowledge if the command was successfully executed
-        // we just say OK there, but you need to add logic if the command is 
+        // we just say OK there, but you need to add logic if the command is
         // really successfully executed on the device
         await uc.acknowledgeCommand(id);
     }

--- a/examples/light.js
+++ b/examples/light.js
@@ -6,47 +6,47 @@ const uc = require('../index');
 uc.init('driver.json');
 
 uc.on(uc.EVENTS.CONNECT, async () => {
-    await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
+  await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
 });
 
 uc.on(uc.EVENTS.DISCONNECT, async () => {
-    await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
+  await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
 });
 
 uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
-    // the integration will configure entities and subscribe for entity update events
-    // the UC library automatically adds the subscribed entities
-    // from available to configured
-    // you can act on this event if you need for your device handling
-    entities.forEach(entity => {
-        console.log(`Subscribed entity: ${JSON.stringify(entity, null, 4)}`);
-    });
+  // the integration will configure entities and subscribe for entity update events
+  // the UC library automatically adds the subscribed entities
+  // from available to configured
+  // you can act on this event if you need for your device handling
+  entities.forEach(entity => {
+    console.log(`Subscribed entity: ${JSON.stringify(entity, null, 4)}`);
+  });
 });
 
 uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
-    // when the integration unsubscribed from certain entity updates,
-    // the UC library automatically remove the unsubscribed entities
-    // from configured
-    // you can act on this event if you need for your device handling
-    entities.forEach(entity => {
-        console.log(`Unsubscribed entity: ${JSON.stringify(entity, null, 4)}`);
-    });
+  // when the integration unsubscribed from certain entity updates,
+  // the UC library automatically remove the unsubscribed entities
+  // from configured
+  // you can act on this event if you need for your device handling
+  entities.forEach(entity => {
+    console.log(`Unsubscribed entity: ${JSON.stringify(entity, null, 4)}`);
+  });
 });
 
 // create a light entity
 // normally you'd create this where your driver exposed the available entities
 const lightEntity = new uc.Entities.Light(
-    'my_unique_light_id',
-    'My favorite light',
-    uc.getDriverVersion().id,
-    [
-        uc.Entities.Light.FEATURES.ON_OFF,
-        uc.Entities.Light.FEATURES.DIM
-    ],
-    {
-        [uc.Entities.Light.ATTRIBUTES.STATE]: uc.Entities.Light.STATES.OFF,
-        [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS]: 0
-    }
+  'my_unique_light_id',
+  'My favorite light',
+  uc.getDriverVersion().id,
+  [
+    uc.Entities.Light.FEATURES.ON_OFF,
+    uc.Entities.Light.FEATURES.DIM
+  ],
+  {
+    [uc.Entities.Light.ATTRIBUTES.STATE]: uc.Entities.Light.STATES.OFF,
+    [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS]: 0
+  }
 );
 
 // add entity as available
@@ -57,64 +57,64 @@ uc.availableEntities.addEntity(lightEntity);
 // in this example we just update the entity, but in reality, you'd turn on the light with your integration
 // and handle the events separately for updating the configured entities
 uc.on(
-    uc.EVENTS.ENTITY_COMMAND,
-    async (id, entity_id, entity_type, cmd_id, params) => {
-        console.log(
-            `ENTITY COMMAND: ${id} ${entity_id} ${entity_type} ${cmd_id} ${JSON.stringify(params, null, 4)}`
-        );
+  uc.EVENTS.ENTITY_COMMAND,
+  async (id, entityId, entityType, cmdId, params) => {
+    console.log(
+            `ENTITY COMMAND: ${id} ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
+    );
 
-        // get the entity from the configured ones
-        const entity = uc.configuredEntities.getEntity(entity_id);
+    // get the entity from the configured ones
+    const entity = uc.configuredEntities.getEntity(entityId);
 
-        if (entity == null) {
-            console.log('Entity not found');
-            await uc.acknowledgeCommand(id, uc.STATUS_CODES.NOT_FOUND);
-            return;
-        }
-
-        switch (cmd_id) {
-        case uc.Entities.Light.COMMANDS.TOGGLE:
-            if (entity.attributes.state === uc.Entities.Light.STATES.OFF) {
-                uc.configuredEntities.updateEntityAttributes(
-                    entity.id,
-                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                    [uc.Entities.Light.STATES.ON, 255]
-                );
-            } else if (entity.attributes.state === uc.Entities.Light.STATES.ON) {
-                uc.configuredEntities.updateEntityAttributes(
-                    entity.id,
-                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                    [uc.Entities.Light.STATES.OFF, 0]
-                );
-            }
-            break;
-        case uc.Entities.Light.COMMANDS.ON:
-            if (params.brightness) {
-                uc.configuredEntities.updateEntityAttributes(
-                    entity.id,
-                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                    [uc.Entities.Light.STATES.ON, params.brightness]
-                );
-            } else {
-                uc.configuredEntities.updateEntityAttributes(
-                    entity.id,
-                    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                    [uc.Entities.Light.STATES.OFF, 0]
-                );
-            }
-            break;
-        case uc.Entities.Light.COMMANDS.OFF:
-            uc.configuredEntities.updateEntityAttributes(
-                entity.id,
-                [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-                [uc.Entities.Light.STATES.OFF, 0]
-            );
-            break;
-        }
-
-        // you need to acknowledge if the command was successfully executed
-        // we just say OK there, but you need to add logic if the command is
-        // really successfully executed on the device
-        await uc.acknowledgeCommand(id);
+    if (entity == null) {
+      console.log('Entity not found');
+      await uc.acknowledgeCommand(id, uc.STATUS_CODES.NOT_FOUND);
+      return;
     }
+
+    switch (cmdId) {
+      case uc.Entities.Light.COMMANDS.TOGGLE:
+        if (entity.attributes.state === uc.Entities.Light.STATES.OFF) {
+          uc.configuredEntities.updateEntityAttributes(
+            entity.id,
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+            [uc.Entities.Light.STATES.ON, 255]
+          );
+        } else if (entity.attributes.state === uc.Entities.Light.STATES.ON) {
+          uc.configuredEntities.updateEntityAttributes(
+            entity.id,
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+            [uc.Entities.Light.STATES.OFF, 0]
+          );
+        }
+        break;
+      case uc.Entities.Light.COMMANDS.ON:
+        if (params.brightness) {
+          uc.configuredEntities.updateEntityAttributes(
+            entity.id,
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+            [uc.Entities.Light.STATES.ON, params.brightness]
+          );
+        } else {
+          uc.configuredEntities.updateEntityAttributes(
+            entity.id,
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+            [uc.Entities.Light.STATES.OFF, 0]
+          );
+        }
+        break;
+      case uc.Entities.Light.COMMANDS.OFF:
+        uc.configuredEntities.updateEntityAttributes(
+          entity.id,
+          [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+          [uc.Entities.Light.STATES.OFF, 0]
+        );
+        break;
+    }
+
+    // you need to acknowledge if the command was successfully executed
+    // we just say OK there, but you need to add logic if the command is
+    // really successfully executed on the device
+    await uc.acknowledgeCommand(id);
+  }
 );

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -7,48 +7,48 @@ uc.init("driver.json");
 // Handling events
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 uc.on(uc.EVENTS.CONNECT, async () => {
-	// act on when the core connects to the integration
-	// for example: start polling your devices
-	uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
+    // act on when the core connects to the integration
+    // for example: start polling your devices
+    uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
 });
 
 uc.on(uc.EVENTS.DISCONNECT, async () => {
-	// act on when the core disconnects from the integration
-	// for example: stop polling your devices
-	uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
+    // act on when the core disconnects from the integration
+    // for example: stop polling your devices
+    uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
 });
 
 uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
-	// the integration will configure entities and subscribe for entity update events
-	// the UC library automatically adds the subscribed entities
-	// from available to configured
-	// you can act on this event if you need for your device handling
+    // the integration will configure entities and subscribe for entity update events
+    // the UC library automatically adds the subscribed entities
+    // from available to configured
+    // you can act on this event if you need for your device handling
 });
 
 uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
-	// when the integration unsubscribed from certain entity updates,
-	// the UC library automatically remove the unsubscribed entities
-	// from configured
-	// you can act on this event if you need for your device handling
+    // when the integration unsubscribed from certain entity updates,
+    // the UC library automatically remove the unsubscribed entities
+    // from configured
+    // you can act on this event if you need for your device handling
 });
 
 // handle commands coming from the core
 uc.on(
-	uc.EVENTS.ENTITY_COMMAND,
-	async (id, entity_id, entity_type, cmd_id, params) => {
-		console.log(
-			`ENTITY COMMAND: ${id} ${entity_id} ${entity_type} ${cmd_id} ${JSON.stringify(params, null, 4)}`
-		);
+    uc.EVENTS.ENTITY_COMMAND,
+    async (id, entity_id, entity_type, cmd_id, params) => {
+        console.log(
+            `ENTITY COMMAND: ${id} ${entity_id} ${entity_type} ${cmd_id} ${JSON.stringify(params, null, 4)}`
+        );
 
-		// handle entity commands here
-		// execute commands on your integration devices
-		// for example start playing a song or change volume
-		// Note: you might need to convert values for your desired range and format
+        // handle entity commands here
+        // execute commands on your integration devices
+        // for example start playing a song or change volume
+        // Note: you might need to convert values for your desired range and format
 
-		// you need to acknoledge if the command was successfully executed
-		// default is uc.STATUS_CODES.OK
-		uc.acknowledgeCommand(id, statusCode);
-	}
+        // you need to acknoledge if the command was successfully executed
+        // default is uc.STATUS_CODES.OK
+        uc.acknowledgeCommand(id, statusCode);
+    }
 );
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -58,21 +58,21 @@ uc.on(
 // your integration should make entities available for the core
 // 1. create an entity
 const entity = new uc.Entities.MediaPlayer(
-	// entity id has to be unique, you can provide it or use uc.Entities.generateId()
-	entity_id,
-	// name of the entity
-	entity_name,
-	// id of the integration driver
-	uc.getDriverVersion().id,
-	// define features in an array. Use the pre-defined object to choose features from
-	[uc.Entities.MediaPlayer.FEATURES.ON_OFF,
-	uc.Entities.MediaPlayer.FEATURES.VOLUME],
-	// define default attributes for the entity. Use the pre-defined object to choose attributes from
-	{
-		[uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
-			uc.Entities.MediaPlayer.STATES.OFF,
-		[uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0,
-	}
+    // entity id has to be unique, you can provide it or use uc.Entities.generateId()
+    entity_id,
+    // name of the entity
+    entity_name,
+    // id of the integration driver
+    uc.getDriverVersion().id,
+    // define features in an array. Use the pre-defined object to choose features from
+    [uc.Entities.MediaPlayer.FEATURES.ON_OFF,
+        uc.Entities.MediaPlayer.FEATURES.VOLUME],
+    // define default attributes for the entity. Use the pre-defined object to choose attributes from
+    {
+        [uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
+        uc.Entities.MediaPlayer.STATES.OFF,
+        [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0,
+    }
 );
 
 // 2. add available entity to the core
@@ -87,17 +87,17 @@ uc.configuredEntities.updateEntityAttributes(entity_id, keys, values);
 
 // for example to update a state fo a media player:
 uc.configuredEntities.updateEntityAttributes(
-	entity_id,
-	[uc.Entities.MediaPlayer.ATTRIBUTES.STATE],
-	[uc.Entities.MediaPlayer.STATES.PLAYING]
+    entity_id,
+    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE],
+    [uc.Entities.MediaPlayer.STATES.PLAYING]
 );
 
 // or multiple attributes at the same time
 uc.configuredEntities.updateEntityAttributes(
-	entity_id,
-	[
-		uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
-		uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST,
-	],
-	[uc.Entities.MediaPlayer.STATES.PLAYING, "Massive Attack"]
+    entity_id,
+    [
+        uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
+        uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST,
+    ],
+    [uc.Entities.MediaPlayer.STATES.PLAYING, "Massive Attack"]
 );

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -7,48 +7,49 @@ uc.init('driver.json');
 // Handling events
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 uc.on(uc.EVENTS.CONNECT, async () => {
-    // act on when the core connects to the integration
-    // for example: start polling your devices
-    uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
+  // act on when the core connects to the integration
+  // for example: start polling your devices
+  await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
 });
 
 uc.on(uc.EVENTS.DISCONNECT, async () => {
-    // act on when the core disconnects from the integration
-    // for example: stop polling your devices
-    uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
+  // act on when the core disconnects from the integration
+  // for example: stop polling your devices
+  await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
 });
 
 uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
-    // the integration will configure entities and subscribe for entity update events
-    // the UC library automatically adds the subscribed entities
-    // from available to configured
-    // you can act on this event if you need for your device handling
+  // the integration will configure entities and subscribe for entity update events
+  // the UC library automatically adds the subscribed entities
+  // from available to configured
+  // you can act on this event if you need for your device handling
 });
 
 uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
-    // when the integration unsubscribed from certain entity updates,
-    // the UC library automatically remove the unsubscribed entities
-    // from configured
-    // you can act on this event if you need for your device handling
+  // when the integration unsubscribed from certain entity updates,
+  // the UC library automatically remove the unsubscribed entities
+  // from configured
+  // you can act on this event if you need for your device handling
 });
 
 // handle commands coming from the core
 uc.on(
-    uc.EVENTS.ENTITY_COMMAND,
-    async (id, entity_id, entity_type, cmd_id, params) => {
-        console.log(
-            `ENTITY COMMAND: ${id} ${entity_id} ${entity_type} ${cmd_id} ${JSON.stringify(params, null, 4)}`
-        );
+  uc.EVENTS.ENTITY_COMMAND,
+  async (id, entityId, entityType, cmdId, params) => {
+    console.log(
+            `ENTITY COMMAND: ${id} ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
+    );
 
-        // handle entity commands here
-        // execute commands on your integration devices
-        // for example start playing a song or change volume
-        // Note: you might need to convert values for your desired range and format
+    // handle entity commands here
+    // execute commands on your integration devices
+    // for example start playing a song or change volume
+    // Note: you might need to convert values for your desired range and format
 
-        // you need to acknoledge if the command was successfully executed
-        // default is uc.STATUS_CODES.OK
-        uc.acknowledgeCommand(id, statusCode);
-    }
+    // you need to acknowledge if the command was successfully executed
+    // default is uc.STATUS_CODES.OK
+    const statusCode = uc.STATUS_CODES.NOT_FOUND;
+    uc.acknowledgeCommand(id, statusCode);
+  }
 );
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -58,21 +59,21 @@ uc.on(
 // your integration should make entities available for the core
 // 1. create an entity
 const entity = new uc.Entities.MediaPlayer(
-    // entity id has to be unique, you can provide it or use uc.Entities.generateId()
-    entity_id,
-    // name of the entity
-    entity_name,
-    // id of the integration driver
-    uc.getDriverVersion().id,
-    // define features in an array. Use the pre-defined object to choose features from
-    [uc.Entities.MediaPlayer.FEATURES.ON_OFF,
-        uc.Entities.MediaPlayer.FEATURES.VOLUME],
-    // define default attributes for the entity. Use the pre-defined object to choose attributes from
-    {
-        [uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
+  // entity id has to be unique, you can provide it or use uc.Entities.generateId()
+  entityId,
+  // name of the entity
+  entityName,
+  // id of the integration driver
+  uc.getDriverVersion().id,
+  // define features in an array. Use the pre-defined object to choose features from
+  [uc.Entities.MediaPlayer.FEATURES.ON_OFF,
+    uc.Entities.MediaPlayer.FEATURES.VOLUME],
+  // define default attributes for the entity. Use the pre-defined object to choose attributes from
+  {
+    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
         uc.Entities.MediaPlayer.STATES.OFF,
-        [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0
-    }
+    [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0
+  }
 );
 
 // 2. add available entity to the core
@@ -83,21 +84,20 @@ uc.availableEntities.addEntity(entity);
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // when your integration driver needs to update an entity based on a device change
 // keys and values are attribute key and value pairs
-uc.configuredEntities.updateEntityAttributes(entity_id, keys, values);
+uc.configuredEntities.updateEntityAttributes(entityId, keys, values);
 
 // for example to update a state fo a media player:
-uc.configuredEntities.updateEntityAttributes(
-    entity_id,
-    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE],
-    [uc.Entities.MediaPlayer.STATES.PLAYING]
+uc.configuredEntities.updateEntityAttributes(entityId,
+  [uc.Entities.MediaPlayer.ATTRIBUTES.STATE],
+  [uc.Entities.MediaPlayer.STATES.PLAYING]
 );
 
 // or multiple attributes at the same time
 uc.configuredEntities.updateEntityAttributes(
-    entity_id,
-    [
-        uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
-        uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST
-    ],
-    [uc.Entities.MediaPlayer.STATES.PLAYING, 'Massive Attack']
+  entityId,
+  [
+    uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
+    uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST
+  ],
+  [uc.Entities.MediaPlayer.STATES.PLAYING, 'Massive Attack']
 );

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
-const uc = require("uc-integration-api");
-uc.init("driver.json");
+const uc = require('uc-integration-api');
+uc.init('driver.json');
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // Handling events
@@ -71,7 +71,7 @@ const entity = new uc.Entities.MediaPlayer(
     {
         [uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
         uc.Entities.MediaPlayer.STATES.OFF,
-        [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0,
+        [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0
     }
 );
 
@@ -97,7 +97,7 @@ uc.configuredEntities.updateEntityAttributes(
     entity_id,
     [
         uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
-        uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST,
+        uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST
     ],
-    [uc.Entities.MediaPlayer.STATES.PLAYING, "Massive Attack"]
+    [uc.Entities.MediaPlayer.STATES.PLAYING, 'Massive Attack']
 );

--- a/index.js
+++ b/index.js
@@ -8,320 +8,320 @@ const uc = require('./lib/api_definitions');
 const Entities = require('./lib/entities/entities');
 
 function log (message) {
-    console.log(`[UC Integration API] ${message}`);
+  console.log(`[UC Integration API] ${message}`);
 }
 
 class IntegrationAPI extends EventEmitter {
-    #driverPath;
-    #driverInfo;
-    #state;
-    #server;
+  #driverPath;
+  #driverInfo;
+  #state;
+  #server;
 
-    constructor () {
-        super();
+  constructor () {
+    super();
 
-        this.#driverPath = 'driver.json';
+    this.#driverPath = 'driver.json';
 
-        // set default state to connected
-        this.#state = uc.DEVICE_STATES.DISCONNECTED;
+    // set default state to connected
+    this.#state = uc.DEVICE_STATES.DISCONNECTED;
 
-        // create storage for available and configured entities
-        this.availableEntities = new Entities('available');
-        this.configuredEntities = new Entities('configured');
+    // create storage for available and configured entities
+    this.availableEntities = new Entities('available');
+    this.configuredEntities = new Entities('configured');
 
-        // connect to update events for entity attributes
-        this.configuredEntities.on(
-            uc.EVENTS.ENTITY_ATTRIBUTES_UPDATED,
-            async (entity_id, entity_type, attributes) => {
-                const data = {
-                    entity_id,
-                    entity_type,
-                    attributes
-                };
+    // connect to update events for entity attributes
+    this.configuredEntities.on(
+      uc.EVENTS.ENTITY_ATTRIBUTES_UPDATED,
+      async (entity_id, entity_type, attributes) => {
+        const data = {
+          entity_id,
+          entity_type,
+          attributes
+        };
 
-                await this.#sendEvent(uc.EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);
-            }
-        );
-    }
+        await this.#sendEvent(uc.EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);
+      }
+    );
+  }
 
-    init (driverPath) {
+  init (driverPath) {
     // load driver information from driver.json
-        this.#driverPath = driverPath;
-        let raw;
+    this.#driverPath = driverPath;
+    let raw;
 
-        try {
-            raw = fs.readFileSync(driverPath);
-        } catch (e) {
-            throw Error(`Cannot load driver.json: ${e}`);
-        }
+    try {
+      raw = fs.readFileSync(driverPath);
+    } catch (e) {
+      throw Error(`Cannot load driver.json: ${e}`);
+    }
 
-        try {
-            this.#driverInfo = JSON.parse(raw);
-            log('Driver info loaded');
-        } catch (e) {
-            log(`Error parsing driver info: ${e}`);
-            throw Error('Error parsing driver info');
-        }
+    try {
+      this.#driverInfo = JSON.parse(raw);
+      log('Driver info loaded');
+    } catch (e) {
+      log(`Error parsing driver info: ${e}`);
+      throw Error('Error parsing driver info');
+    }
 
-        // setup websocket server - remote-core will connect to this
-        this.#server = new WebSocket.Server({ port: this.#driverInfo.port });
+    // setup websocket server - remote-core will connect to this
+    this.#server = new WebSocket.Server({ port: this.#driverInfo.port });
+    this.connection = null;
+
+    this.#server.on('connection', (connection, req) => {
+      log('WS: New connection');
+      this.connection = connection;
+
+      this.#authentication(true);
+
+      connection.on('message', async (message) => {
+        await this.#messageReceived(message);
+      });
+
+      connection.on('close', () => {
+        log('WS: Connection closed');
         this.connection = null;
+      });
 
-        this.#server.on('connection', (connection, req) => {
-            log('WS: New connection');
-            this.connection = connection;
+      connection.on('error', () => {
+        log('WS: Connection error');
+        this.connection = null;
+      });
+    });
+  }
 
-            this.#authentication(true);
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+  async #sendOkResult (id, msgData = null) {
+    await this.#sendResponse(id, 'result', msgData, 200);
+  }
 
-            connection.on('message', async (message) => {
-                await this.#messageReceived(message);
-            });
+  async #sendErrorResult (id, statusCode = 500, msgData = null) {
+    await this.#sendResponse(id, 'result', msgData, statusCode);
+  }
 
-            connection.on('close', () => {
-                log('WS: Connection closed');
-                this.connection = null;
-            });
+  // send a response to a request
+  async #sendResponse (id, msg, msgData, statusCode = uc.STATUS_CODES.OK) {
+    const json = {
+      kind: 'resp',
+      req_id: id,
+      code: statusCode,
+      msg,
+      msg_data: msgData
+    };
 
-            connection.on('error', () => {
-                log('WS: Connection error');
-                this.connection = null;
-            });
-        });
+    if (this.connection != null) {
+      const response = JSON.stringify(json);
+      log(`Sending response: ${response}`);
+      this.connection.send(response);
+    } else {
+      log('Error sending response: connection not established');
+    }
+  }
+
+  // send an event
+  async #sendEvent (msg, msgData, cat) {
+    const json = {
+      kind: 'event',
+      msg,
+      msg_data: msgData,
+      cat
+    };
+
+    if (this.connection != null) {
+      const response = JSON.stringify(json);
+      log(`Sending event: ${response}`);
+      this.connection.send(response);
+    }
+  }
+
+  // process incoming websocket messages
+  async #messageReceived (message) {
+    let json;
+    try {
+      json = JSON.parse(message);
+    } catch (e) {
+      log(`Json parse error: ${e}`);
+      return;
     }
 
-    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-    async #sendOkResult (id, msgData = null) {
-        await this.#sendResponse(id, 'result', msgData, 200);
-    }
+    log(`Incoming: ${JSON.stringify(json)}`);
 
-    async #sendErrorResult (id, statusCode = 500, msgData = null) {
-        await this.#sendResponse(id, 'result', msgData, statusCode);
-    }
+    const kind = json.kind;
+    const id = json.id;
+    const msg = json.msg;
+    const msgData = json.msg_data;
 
-    // send a response to a request
-    async #sendResponse (id, msg, msgData, statusCode = uc.STATUS_CODES.OK) {
-        const json = {
-            kind: 'resp',
-            req_id: id,
-            code: statusCode,
-            msg,
-            msg_data: msgData
-        };
-
-        if (this.connection != null) {
-            const response = JSON.stringify(json);
-            log(`Sending response: ${response}`);
-            this.connection.send(response);
-        } else {
-            log('Error sending response: connection not established');
-        }
-    }
-
-    // send an event
-    async #sendEvent (msg, msgData, cat) {
-        const json = {
-            kind: 'event',
-            msg,
-            msg_data: msgData,
-            cat
-        };
-
-        if (this.connection != null) {
-            const response = JSON.stringify(json);
-            log(`Sending event: ${response}`);
-            this.connection.send(response);
-        }
-    }
-
-    // process incoming websocket messages
-    async #messageReceived (message) {
-        let json;
-        try {
-            json = JSON.parse(message);
-        } catch (e) {
-            log(`Json parse error: ${e}`);
-            return;
-        }
-
-        log(`Incoming: ${JSON.stringify(json)}`);
-
-        const kind = json.kind;
-        const id = json.id;
-        const msg = json.msg;
-        const msgData = json.msg_data;
-
-        if (kind === 'req') {
-            switch (msg) {
-            case uc.MESSAGES.GET_DRIVER_VERSION:
-                await this.#sendResponse(
-                    id,
-                    uc.EVENTS.DRIVER_VERSION,
-                    this.getDriverVersion()
-                );
-                break;
-
-            case uc.MESSAGES.GET_DEVICE_STATE:
-                await this.#sendResponse(
-                    id,
-                    uc.EVENTS.DEVICE_STATE,
-                    this.#getDeviceState()
-                );
-                break;
-
-            case uc.MESSAGES.GET_AVAILABLE_ENTITIES:
-                await this.#sendResponse(id, uc.EVENTS.AVAILABLE_ENTITIES, {
-                    available_entities: this.#getAvailableEntities()
-                });
-                break;
-
-            case uc.MESSAGES.GET_ENTITY_STATES:
-                await this.#sendResponse(
-                    id,
-                    uc.EVENTS.ENTITY_STATES,
-                    this.#getEntityStates()
-                );
-                break;
-
-            case uc.MESSAGES.ENTITY_COMMAND:
-                await this.#entityCommand(id, msgData);
-                break;
-
-            case uc.MESSAGES.SUBSCRIBE_EVENTS:
-                if (await this.#subscribeEvents(msgData)) {
-                    await this.#sendOkResult(id);
-                } else {
-                    await this.#sendErrorResult(id, uc.STATUS_CODES.NOT_FOUND);
-                }
-                break;
-
-            case uc.MESSAGES.UNSUBSCRIBE_EVENTS:
-                await this.#unSubscribeEvents(msgData);
-
-                await this.#sendOkResult(id);
-                break;
-
-            default:
-                break;
-            }
-        } else if (kind === 'event') {
-            switch (msg) {
-            case uc.EVENTS.CONNECT:
-                this.emit(uc.EVENTS.CONNECT);
-                break;
-
-            case uc.EVENTS.DISCONNECT:
-                this.emit(uc.EVENTS.DISCONNECT);
-                break;
-
-            default:
-                break;
-            }
-        }
-    }
-
-    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
-    // private methods
-    #authentication (success) {
-        this.#sendResponse(
-            0,
-            uc.MESSAGES.AUTHENTICATION,
-            null,
-            success ? uc.STATUS_CODES.OK : uc.STATUS_CODES.UNAUTHORIZED
-        );
-    }
-
-    #getDeviceState () {
-        return {
-            state: this.#state
-        };
-    }
-
-    #getAvailableEntities () {
-    // return list of entities
-        return this.availableEntities.getEntities();
-    }
-
-    async #subscribeEvents (entities) {
-    // copy available entities to registered entities
-        let res = true;
-
-        entities.entity_ids.forEach((entityId) => {
-            const entity = this.availableEntities.getEntity(entityId);
-            if (entity != null) {
-                if (!this.configuredEntities.addEntity(entity)) {
-                    res = false;
-                }
-            }
-        });
-
-        this.configuredEntities.saveData();
-
-        this.emit(uc.EVENTS.SUBSCRIBE_ENTITIES, entities.entity_ids);
-
-        return res;
-    }
-
-    async #unSubscribeEvents (entities) {
-    // remove entities from registered entities
-        let res = true;
-
-        entities.entity_ids.forEach((entityId) => {
-            if (!this.configuredEntities.removeEntity(entityId)) {
-                res = false;
-            }
-        });
-
-        this.configuredEntities.saveData();
-
-        this.emit(uc.EVENTS.UNSUBSCRIBE_ENTITIES, entities.entity_ids);
-
-        return res;
-    }
-
-    #getEntityStates () {
-    // simply return entity states from configured entities
-        return this.configuredEntities.getStates();
-    }
-
-    async #entityCommand (id, data) {
-    // emit event, so the driver can act on it
-        this.emit(
-            uc.MESSAGES.ENTITY_COMMAND,
+    if (kind === 'req') {
+      switch (msg) {
+        case uc.MESSAGES.GET_DRIVER_VERSION:
+          await this.#sendResponse(
             id,
-            data.entity_id,
-            data.entity_type,
-            data.cmd_id,
-            data.params
-        );
-    }
+            uc.EVENTS.DRIVER_VERSION,
+            this.getDriverVersion()
+          );
+          break;
 
-    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-    getDriverVersion () {
-        return {
-            name: this.#driverInfo.name.en,
-            version: {
-                api: this.#driverInfo.min_core_api,
-                driver: this.#driverInfo.version
-            }
-        };
-    }
-
-    async setDeviceState (state) {
-        this.#state = state;
-
-        await this.#sendEvent(
+        case uc.MESSAGES.GET_DEVICE_STATE:
+          await this.#sendResponse(
+            id,
             uc.EVENTS.DEVICE_STATE,
-            {
-                state: this.#state
-            },
-            uc.EVENT_CATEGORY.DEVICE
-        );
-    }
+            this.#getDeviceState()
+          );
+          break;
 
-    async acknowledgeCommand (id, statusCode = uc.STATUS_CODES.OK) {
-        await this.#sendResponse(id, 'result', null, statusCode);
+        case uc.MESSAGES.GET_AVAILABLE_ENTITIES:
+          await this.#sendResponse(id, uc.EVENTS.AVAILABLE_ENTITIES, {
+            available_entities: this.#getAvailableEntities()
+          });
+          break;
+
+        case uc.MESSAGES.GET_ENTITY_STATES:
+          await this.#sendResponse(
+            id,
+            uc.EVENTS.ENTITY_STATES,
+            this.#getEntityStates()
+          );
+          break;
+
+        case uc.MESSAGES.ENTITY_COMMAND:
+          await this.#entityCommand(id, msgData);
+          break;
+
+        case uc.MESSAGES.SUBSCRIBE_EVENTS:
+          if (await this.#subscribeEvents(msgData)) {
+            await this.#sendOkResult(id);
+          } else {
+            await this.#sendErrorResult(id, uc.STATUS_CODES.NOT_FOUND);
+          }
+          break;
+
+        case uc.MESSAGES.UNSUBSCRIBE_EVENTS:
+          await this.#unSubscribeEvents(msgData);
+
+          await this.#sendOkResult(id);
+          break;
+
+        default:
+          break;
+      }
+    } else if (kind === 'event') {
+      switch (msg) {
+        case uc.EVENTS.CONNECT:
+          this.emit(uc.EVENTS.CONNECT);
+          break;
+
+        case uc.EVENTS.DISCONNECT:
+          this.emit(uc.EVENTS.DISCONNECT);
+          break;
+
+        default:
+          break;
+      }
     }
+  }
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+  // private methods
+  #authentication (success) {
+    this.#sendResponse(
+      0,
+      uc.MESSAGES.AUTHENTICATION,
+      null,
+      success ? uc.STATUS_CODES.OK : uc.STATUS_CODES.UNAUTHORIZED
+    );
+  }
+
+  #getDeviceState () {
+    return {
+      state: this.#state
+    };
+  }
+
+  #getAvailableEntities () {
+    // return list of entities
+    return this.availableEntities.getEntities();
+  }
+
+  async #subscribeEvents (entities) {
+    // copy available entities to registered entities
+    let res = true;
+
+    entities.entity_ids.forEach((entityId) => {
+      const entity = this.availableEntities.getEntity(entityId);
+      if (entity != null) {
+        if (!this.configuredEntities.addEntity(entity)) {
+          res = false;
+        }
+      }
+    });
+
+    this.configuredEntities.saveData();
+
+    this.emit(uc.EVENTS.SUBSCRIBE_ENTITIES, entities.entity_ids);
+
+    return res;
+  }
+
+  async #unSubscribeEvents (entities) {
+    // remove entities from registered entities
+    let res = true;
+
+    entities.entity_ids.forEach((entityId) => {
+      if (!this.configuredEntities.removeEntity(entityId)) {
+        res = false;
+      }
+    });
+
+    this.configuredEntities.saveData();
+
+    this.emit(uc.EVENTS.UNSUBSCRIBE_ENTITIES, entities.entity_ids);
+
+    return res;
+  }
+
+  #getEntityStates () {
+    // simply return entity states from configured entities
+    return this.configuredEntities.getStates();
+  }
+
+  async #entityCommand (id, data) {
+    // emit event, so the driver can act on it
+    this.emit(
+      uc.MESSAGES.ENTITY_COMMAND,
+      id,
+      data.entity_id,
+      data.entity_type,
+      data.cmd_id,
+      data.params
+    );
+  }
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+  getDriverVersion () {
+    return {
+      name: this.#driverInfo.name.en,
+      version: {
+        api: this.#driverInfo.min_core_api,
+        driver: this.#driverInfo.version
+      }
+    };
+  }
+
+  async setDeviceState (state) {
+    this.#state = state;
+
+    await this.#sendEvent(
+      uc.EVENTS.DEVICE_STATE,
+      {
+        state: this.#state
+      },
+      uc.EVENT_CATEGORY.DEVICE
+    );
+  }
+
+  async acknowledgeCommand (id, statusCode = uc.STATUS_CODES.OK) {
+    await this.#sendResponse(id, 'result', null, statusCode);
+  }
 }
 
 module.exports = new IntegrationAPI();

--- a/index.js
+++ b/index.js
@@ -8,315 +8,321 @@ const uc = require("./lib/api_definitions");
 const Entities = require("./lib/entities/entities");
 
 function log(message) {
-	console.log(`[UC Integration API] ${message}`);
+    console.log(`[UC Integration API] ${message}`);
 }
 
 class IntegrationAPI extends EventEmitter {
-	#driverPath;
-	#driverInfo;
-	#state;
-	#server;
+    #driverPath;
+    #driverInfo;
+    #state;
+    #server;
 
-	constructor() {
-		super();
+    constructor() {
+        super();
 
-		this.#driverPath = "driver.json";
+        this.#driverPath = "driver.json";
 
-		// set default state to connected
-		this.#state = uc.DEVICE_STATES.DISCONNECTED;
+        // set default state to connected
+        this.#state = uc.DEVICE_STATES.DISCONNECTED;
 
-		// create storage for available and configured entities
-		this.availableEntities = new Entities("available");
-		this.configuredEntities = new Entities("configured");
+        // create storage for available and configured entities
+        this.availableEntities = new Entities("available");
+        this.configuredEntities = new Entities("configured");
 
-		// connect to update events for entity attributes
-		this.configuredEntities.on(
-			uc.EVENTS.ENTITY_ATTRIBUTES_UPDATED,
-			async (entity_id, entity_type, attributes) => {
-				const data = {
-					entity_id: entity_id,
-					entity_type: entity_type,
-					attributes: attributes,
-				};
+        // connect to update events for entity attributes
+        this.configuredEntities.on(
+            uc.EVENTS.ENTITY_ATTRIBUTES_UPDATED,
+            async (entity_id, entity_type, attributes) => {
+                const data = {
+                    entity_id: entity_id,
+                    entity_type: entity_type,
+                    attributes: attributes,
+                };
 
-				await this.#sendEvent(uc.EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);
-			}
-		);
-	}
+                await this.#sendEvent(uc.EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);
+            }
+        );
+    }
 
-	init(driverPath) {
-		// load driver information from driver.json
-		this.#driverPath = driverPath;
-		let raw;
+    init(driverPath) {
+        // load driver information from driver.json
+        this.#driverPath = driverPath;
+        let raw;
 
-		try {
-			raw = fs.readFileSync(driverPath);
-		} catch (e) {
-			throw Error(`Cannot load driver.json: ${e}`)
-		}
+        try {
+            raw = fs.readFileSync(driverPath);
+        } catch (e) {
+            throw Error(`Cannot load driver.json: ${e}`)
+        }
 
-		try {
-			this.#driverInfo = JSON.parse(raw);
-			log("Driver info loaded");
-		} catch (e) {
-			log(`Error parsing driver info: ${e}`);
-			throw Error("Error parsing driver info")
+        try {
+            this.#driverInfo = JSON.parse(raw);
+            log("Driver info loaded");
+        } catch (e) {
+            log(`Error parsing driver info: ${e}`);
+            throw Error("Error parsing driver info")
 
-		}
+        }
 
-		// setup websocket server - remote-core will connect to this
-		this.#server = new WebSocket.Server({ port: this.#driverInfo.port });
-		this.connection = null;
+        // setup websocket server - remote-core will connect to this
+        this.#server = new WebSocket.Server({port: this.#driverInfo.port});
+        this.connection = null;
 
-		this.#server.on("connection", (connection, req) => {
-			log("WS: New connection");
-			this.connection = connection;
+        this.#server.on("connection", (connection, req) => {
+            log("WS: New connection");
+            this.connection = connection;
 
-			this.#authentication(true);
+            this.#authentication(true);
 
-			connection.on("message", async (message) => {
-				await this.#messageReceived(message);
-			});
+            connection.on("message", async (message) => {
+                await this.#messageReceived(message);
+            });
 
-			connection.on("close", () => {
-				log("WS: Connection closed");
-				this.connection = null;
-			});
+            connection.on("close", () => {
+                log("WS: Connection closed");
+                this.connection = null;
+            });
 
-			connection.on("error", () => {
-				log("WS: Connection error");
-				this.connection = null;
-			});
-		});
-	}
+            connection.on("error", () => {
+                log("WS: Connection error");
+                this.connection = null;
+            });
+        });
+    }
 
-	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	// send a response to a request
-	async #sendResponse(id, msg = "result", msgData, statusCode = uc.STATUS_CODES.OK) {
-		const json = {
-			kind: "resp",
-			req_id: id,
-			code: statusCode,
-			msg,
-			msg_data: msgData,
-		};
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+    async #sendOkResult(id, msgData = null) {
+        await this.#sendResponse(id, "result", msgData, 200);
+    }
 
-		if (this.connection != null) {
-			const response = JSON.stringify(json);
-			log(`Sending response: ${response}`);
-			this.connection.send(response);
-		}
-	}
+    async #sendErrorResult(id, statusCode = 500, msgData = null) {
+        await this.#sendResponse(id, "result", msgData, statusCode);
+    }
 
-	// send an event
-	async #sendEvent(msg, msgData, cat) {
-		const json = {
-			kind: "event",
-			msg,
-			msg_data: msgData,
-			cat: cat,
-		};
+    // send a response to a request
+    async #sendResponse(id, msg, msgData, statusCode = uc.STATUS_CODES.OK) {
+        const json = {
+            kind: "resp",
+            req_id: id,
+            code: statusCode,
+            msg,
+            msg_data: msgData,
+        };
 
-		if (this.connection != null) {
-			const response = JSON.stringify(json);
-			log(`Sending event: ${response}`);
-			this.connection.send(response);
-		}
-	}
+        if (this.connection != null) {
+            const response = JSON.stringify(json);
+            log(`Sending response: ${response}`);
+            this.connection.send(response);
+        } else {
+            log("Error sending response: connection not established");
+        }
+    }
 
-	// process incoming websocket messages
-	async #messageReceived(message) {
-		let json;
-		try {
-			json = JSON.parse(message);
-		} catch (e) {
-			log(`Json parse error: ${e}`);
-			return;
-		}
+    // send an event
+    async #sendEvent(msg, msgData, cat) {
+        const json = {
+            kind: "event",
+            msg,
+            msg_data: msgData,
+            cat: cat,
+        };
 
-		log(`Incoming: ${JSON.stringify(json)}`);
+        if (this.connection != null) {
+            const response = JSON.stringify(json);
+            log(`Sending event: ${response}`);
+            this.connection.send(response);
+        }
+    }
 
-		const kind = json.kind;
-		const id = json.id;
-		const msg = json.msg;
-		const msgData = json.msg_data;
+    // process incoming websocket messages
+    async #messageReceived(message) {
+        let json;
+        try {
+            json = JSON.parse(message);
+        } catch (e) {
+            log(`Json parse error: ${e}`);
+            return;
+        }
 
-		if (kind === "req") {
-			switch (msg) {
-				case uc.MESSAGES.GET_DRIVER_VERSION:
-					await this.#sendResponse(
-						id,
-						uc.EVENTS.DRIVER_VERSION,
-						this.getDriverVersion()
-					);
-					break;
+        log(`Incoming: ${JSON.stringify(json)}`);
 
-				case uc.MESSAGES.GET_DEVICE_STATE:
-					await this.#sendResponse(
-						id,
-						uc.EVENTS.DEVICE_STATE,
-						this.#getDeviceState()
-					);
-					break;
+        const kind = json.kind;
+        const id = json.id;
+        const msg = json.msg;
+        const msgData = json.msg_data;
 
-				case uc.MESSAGES.GET_AVAILABLE_ENTITIES:
-					await this.#sendResponse(id, uc.EVENTS.AVAILABLE_ENTITIES, {
-						available_entities: this.#getAvailableEntities(),
-					});
-					break;
+        if (kind === "req") {
+            switch (msg) {
+                case uc.MESSAGES.GET_DRIVER_VERSION:
+                    await this.#sendResponse(
+                        id,
+                        uc.EVENTS.DRIVER_VERSION,
+                        this.getDriverVersion()
+                    );
+                    break;
 
-				case uc.MESSAGES.GET_ENTITY_STATES:
-					await this.#sendResponse(
-						id,
-						uc.EVENTS.ENTITY_STATES,
-						this.#getEntityStates()
-					);
-					break;
+                case uc.MESSAGES.GET_DEVICE_STATE:
+                    await this.#sendResponse(
+                        id,
+                        uc.EVENTS.DEVICE_STATE,
+                        this.#getDeviceState()
+                    );
+                    break;
 
-				case uc.MESSAGES.ENTITY_COMMAND:
-					await this.#entityCommand(id, msgData);
-					break;
+                case uc.MESSAGES.GET_AVAILABLE_ENTITIES:
+                    await this.#sendResponse(id, uc.EVENTS.AVAILABLE_ENTITIES, {
+                        available_entities: this.#getAvailableEntities(),
+                    });
+                    break;
 
-				case uc.MESSAGES.SUBSCRIBE_EVENTS:
-					await this.#sendResponse(
-						id,
-						"result",
-						null,
-						await this.#subscribeEvents(msgData) ? uc.STATUS_CODES.OK : uc.STATUS_CODES.NOT_FOUND
-					);
-					break;
+                case uc.MESSAGES.GET_ENTITY_STATES:
+                    await this.#sendResponse(
+                        id,
+                        uc.EVENTS.ENTITY_STATES,
+                        this.#getEntityStates()
+                    );
+                    break;
 
-				case uc.MESSAGES.UNSUBSCRIBE_EVENTS:
-					await this.#unSubscribeEvents(msgData);
+                case uc.MESSAGES.ENTITY_COMMAND:
+                    await this.#entityCommand(id, msgData);
+                    break;
 
-					await this.#sendResponse(
-						id,
-						"result",
-						null
-					);
-					break;
+                case uc.MESSAGES.SUBSCRIBE_EVENTS:
+                    if (await this.#subscribeEvents(msgData)) {
+                        await this.#sendOkResult(id);
+                    } else {
+                        await this.#sendErrorResult(id, uc.STATUS_CODES.NOT_FOUND);
+                    }
+                    break;
 
-				default:
-					break;
-			}
-		} else if (kind === "event") {
-			switch (msg) {
-				case uc.EVENTS.CONNECT:
-					this.emit(uc.EVENTS.CONNECT);
-					break;
+                case uc.MESSAGES.UNSUBSCRIBE_EVENTS:
+                    await this.#unSubscribeEvents(msgData);
 
-				case uc.EVENTS.DISCONNECT:
-					this.emit(uc.EVENTS.DISCONNECT);
-					break;
+                    await this.#sendOkResult(id);
+                    break;
 
-				default:
-					break;
-			}
-		}
-	}
+                default:
+                    break;
+            }
+        } else if (kind === "event") {
+            switch (msg) {
+                case uc.EVENTS.CONNECT:
+                    this.emit(uc.EVENTS.CONNECT);
+                    break;
 
-	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	// private methods
-	#authentication(success) {
-		this.#sendResponse(
-			0,
-			uc.MESSAGES.AUTHENTICATION,
-			null,
-			success ? uc.STATUS_CODES.OK : uc.STATUS_CODES.UNAUTHORIZED
-		);
-	}
+                case uc.EVENTS.DISCONNECT:
+                    this.emit(uc.EVENTS.DISCONNECT);
+                    break;
 
-	#getDeviceState() {
-		return {
-			state: this.#state,
-		};
-	}
+                default:
+                    break;
+            }
+        }
+    }
 
-	#getAvailableEntities() {
-		// return list of entities
-		return this.availableEntities.getEntities();
-	}
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-	async #subscribeEvents(entities) {
-		// copy available entities to registered entities
-		let res = true;
+    // private methods
+    #authentication(success) {
+        this.#sendResponse(
+            0,
+            uc.MESSAGES.AUTHENTICATION,
+            null,
+            success ? uc.STATUS_CODES.OK : uc.STATUS_CODES.UNAUTHORIZED
+        );
+    }
 
-		entities.entity_ids.forEach((entityId) => {
-			const entity = this.availableEntities.getEntity(entityId);
-			if (entity != null) {
-				if (!this.configuredEntities.addEntity(entity)) {
-					res = false;
-				}
-			}
-		});
+    #getDeviceState() {
+        return {
+            state: this.#state,
+        };
+    }
 
-		this.configuredEntities.saveData();
+    #getAvailableEntities() {
+        // return list of entities
+        return this.availableEntities.getEntities();
+    }
 
-		this.emit(uc.EVENTS.SUBSCRIBE_ENTITIES, entities.entity_ids);
+    async #subscribeEvents(entities) {
+        // copy available entities to registered entities
+        let res = true;
 
-		return res;
-	}
+        entities.entity_ids.forEach((entityId) => {
+            const entity = this.availableEntities.getEntity(entityId);
+            if (entity != null) {
+                if (!this.configuredEntities.addEntity(entity)) {
+                    res = false;
+                }
+            }
+        });
 
-	async #unSubscribeEvents(entities) {
-		// remove entities from registered entities
-		let res = true;
+        this.configuredEntities.saveData();
 
-		entities.entity_ids.forEach((entityId) => {
-			if (!this.configuredEntities.removeEntity(entityId)) {
-				res = false;
-			}
-		});
+        this.emit(uc.EVENTS.SUBSCRIBE_ENTITIES, entities.entity_ids);
 
-		this.configuredEntities.saveData();
+        return res;
+    }
 
-		this.emit(uc.EVENTS.UNSUBSCRIBE_ENTITIES, entities.entity_ids);
+    async #unSubscribeEvents(entities) {
+        // remove entities from registered entities
+        let res = true;
 
-		return res;
-	}
+        entities.entity_ids.forEach((entityId) => {
+            if (!this.configuredEntities.removeEntity(entityId)) {
+                res = false;
+            }
+        });
 
-	#getEntityStates() {
-		// simply return entity states from configured entities
-		return this.configuredEntities.getStates();
-	}
+        this.configuredEntities.saveData();
 
-	async #entityCommand(id, data) {
-		// emit event, so the driver can act on it
-		this.emit(
-			uc.MESSAGES.ENTITY_COMMAND,
-			id,
-			data.entity_id,
-			data.entity_type,
-			data.cmd_id,
-			data.params
-		);
-	}
+        this.emit(uc.EVENTS.UNSUBSCRIBE_ENTITIES, entities.entity_ids);
 
-	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	getDriverVersion() {
-		return {
-			name: this.#driverInfo.name.en,
-			version: {
-				api: this.#driverInfo.min_core_api,
-				driver: this.#driverInfo.version,
-			},
-		};
-	}
+        return res;
+    }
 
-	async setDeviceState(state) {
-		this.#state = state;
+    #getEntityStates() {
+        // simply return entity states from configured entities
+        return this.configuredEntities.getStates();
+    }
 
-		await this.#sendEvent(
-			uc.EVENTS.DEVICE_STATE,
-			{
-				state: this.#state,
-			},
-			uc.EVENT_CATEGORY.DEVICE
-		);
-	}
+    async #entityCommand(id, data) {
+        // emit event, so the driver can act on it
+        this.emit(
+            uc.MESSAGES.ENTITY_COMMAND,
+            id,
+            data.entity_id,
+            data.entity_type,
+            data.cmd_id,
+            data.params
+        );
+    }
 
-	async acknowledgeCommand(id, statusCode = uc.STATUS_CODES.OK) {
-		await this.#sendResponse(id, "result", null, statusCode);
-	}
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+    getDriverVersion() {
+        return {
+            name: this.#driverInfo.name.en,
+            version: {
+                api: this.#driverInfo.min_core_api,
+                driver: this.#driverInfo.version,
+            },
+        };
+    }
+
+    async setDeviceState(state) {
+        this.#state = state;
+
+        await this.#sendEvent(
+            uc.EVENTS.DEVICE_STATE,
+            {
+                state: this.#state,
+            },
+            uc.EVENT_CATEGORY.DEVICE
+        );
+    }
+
+    async acknowledgeCommand(id, statusCode = uc.STATUS_CODES.OK) {
+        await this.#sendResponse(id, "result", null, statusCode);
+    }
 }
 
 module.exports = new IntegrationAPI();

--- a/lib/api_definitions.js
+++ b/lib/api_definitions.js
@@ -1,58 +1,58 @@
-"use strict";
+'use strict';
 
 const DEVICE_STATES = {
-	CONNECTED: "CONNECTED",
-	CONNECTING: "CONNECTING",
-	DISCONNECTED: "DISCONNECTED",
-	ERROR: "ERROR",
+  CONNECTED: 'CONNECTED',
+  CONNECTING: 'CONNECTING',
+  DISCONNECTED: 'DISCONNECTED',
+  ERROR: 'ERROR'
 };
 
 module.exports.DEVICE_STATES = DEVICE_STATES;
 
 const STATUS_CODES = {
-	OK: 200,
-	UNAUTHORIZED: 401,
-	NOT_FOUND: 404,
-	SERVER_ERROR: 500
+  OK: 200,
+  UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
+  SERVER_ERROR: 500
 };
 
 module.exports.STATUS_CODES = STATUS_CODES;
 
 const MESSAGES = {
-	AUTHENTICATION: "authentication",
-	GET_DRIVER_VERSION: "get_driver_version",
-	GET_DEVICE_STATE: "get_device_state",
-	GET_AVAILABLE_ENTITIES: "get_available_entities",
-	GET_ENTITY_STATES: "get_entity_states",
-	SUBSCRIBE_EVENTS: "subscribe_events",
-	UNSUBSCRIBE_EVENTS: "unsubscribe_events",
-	ENTITY_COMMAND: "entity_command",
+  AUTHENTICATION: 'authentication',
+  GET_DRIVER_VERSION: 'get_driver_version',
+  GET_DEVICE_STATE: 'get_device_state',
+  GET_AVAILABLE_ENTITIES: 'get_available_entities',
+  GET_ENTITY_STATES: 'get_entity_states',
+  SUBSCRIBE_EVENTS: 'subscribe_events',
+  UNSUBSCRIBE_EVENTS: 'unsubscribe_events',
+  ENTITY_COMMAND: 'entity_command'
 };
 
 module.exports.MESSAGES = MESSAGES;
 
 const EVENTS = {
-	// own events
-	ENTITY_COMMAND: "entity_command",
-	ENTITY_ATTRIBUTES_UPDATED: "entity_attributes_updated",
-	SUBSCRIBE_ENTITIES: "subscribe_entities",
-	UNSUBSCRIBE_ENTITIES: "unsubscribe_entities",
+  // own events
+  ENTITY_COMMAND: 'entity_command',
+  ENTITY_ATTRIBUTES_UPDATED: 'entity_attributes_updated',
+  SUBSCRIBE_ENTITIES: 'subscribe_entities',
+  UNSUBSCRIBE_ENTITIES: 'unsubscribe_entities',
 
-	// integration api events
-	CONNECT: "connect",
-	DISCONNECT: "disconnect",
-	DRIVER_VERSION: "driver_version",
-	DEVICE_STATE: "device_state",
-	AVAILABLE_ENTITIES: "available_entities",
-	ENTITY_STATES: "entity_states",
-	ENTITY_CHANGE: "entity_change",
+  // integration api events
+  CONNECT: 'connect',
+  DISCONNECT: 'disconnect',
+  DRIVER_VERSION: 'driver_version',
+  DEVICE_STATE: 'device_state',
+  AVAILABLE_ENTITIES: 'available_entities',
+  ENTITY_STATES: 'entity_states',
+  ENTITY_CHANGE: 'entity_change'
 };
 
 module.exports.EVENTS = EVENTS;
 
 const EVENT_CATEGORY = {
-	DEVICE: "DEVICE",
-	ENTITY: "ENTITY",
+  DEVICE: 'DEVICE',
+  ENTITY: 'ENTITY'
 };
 
 module.exports.EVENT_CATEGORY = EVENT_CATEGORY;

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	AVAILABLE: "AVAILABLE",
+  UNAVAILABLE: 'UNAVAILABLE',
+  AVAILABLE: 'AVAILABLE'
 };
 
 const ATTRIBUTES = {
-	STATE: "AVAILABLE",
+  STATE: 'AVAILABLE'
 };
 
 class Button extends Entity {
-	constructor(id, name, device_id, area) {
-		super(id, name, Entity.TYPES.BUTTON, device_id, ["press"], {}, area);
+  constructor (id, name, deviceId, area) {
+    super(id, name, Entity.TYPES.BUTTON, deviceId, ['press'], {}, area);
 
-		console.debug(`Button entity created with id: ${this.id}`);
-	}
+    console.debug(`Button entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Button;

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -1,81 +1,81 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	OFF: "OFF",
-	HEAT: "HEAT",
-	COOL: "COOL",
-	HEAT_COOL: "HEAT_COOL",
-	FAN: "FAN",
-	AUTO: "AUTO",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  OFF: 'OFF',
+  HEAT: 'HEAT',
+  COOL: 'COOL',
+  HEAT_COOL: 'HEAT_COOL',
+  FAN: 'FAN',
+  AUTO: 'AUTO'
 };
 
 const FEATURES = {
-	ON_OFF: "on_off",
-	HEAT: "heat",
-	COOL: "cool",
-	CURRENT_TEMPERATURE: "current_temperature",
-	TARGET_TEMPERATURE: "target_temperature",
-	TARGET_TEMPERATURE_RANGE: "target_temperature_range",
-	FAN: "fan",
+  ON_OFF: 'on_off',
+  HEAT: 'heat',
+  COOL: 'cool',
+  CURRENT_TEMPERATURE: 'current_temperature',
+  TARGET_TEMPERATURE: 'target_temperature',
+  TARGET_TEMPERATURE_RANGE: 'target_temperature_range',
+  FAN: 'fan'
 };
 
 const ATTRIBUTES = {
-	STATE: "state",
-	CURRENT_TEMPERATURE: "current_temperature",
-	TARGET_TEMPERATURE: "target_temperature",
-	TARGET_TEMPERATURE_HIGH: "target_temperature_high",
-	TARGET_TEMPERATURE_LOW: "target_temperature_low",
-	FAN_MODE: "fan_mode",
+  STATE: 'state',
+  CURRENT_TEMPERATURE: 'current_temperature',
+  TARGET_TEMPERATURE: 'target_temperature',
+  TARGET_TEMPERATURE_HIGH: 'target_temperature_high',
+  TARGET_TEMPERATURE_LOW: 'target_temperature_low',
+  FAN_MODE: 'fan_mode'
 };
 
 const COMMANDS = {
-	ON: "on",
-	OFF: "off",
-	HVAC_MODE: "hvac_mode",
-	TARGET_TEMPERATURE: "target_temperature",
-	TARGET_TEMPERATURE_RANGE: "target_temperature_range",
-	FAN_MODE: "fan_mode",
+  ON: 'on',
+  OFF: 'off',
+  HVAC_MODE: 'hvac_mode',
+  TARGET_TEMPERATURE: 'target_temperature',
+  TARGET_TEMPERATURE_RANGE: 'target_temperature_range',
+  FAN_MODE: 'fan_mode'
 };
 
 const DEVICECLASSES = {};
 
 const OPTIONS = {
-	TEMPERATURE_UNIT: "temperature_unit",
-	TARGET_TEMPERATURE_STEP: "target_temperature_step",
-	MAX_TEMPERATURE: "max_temperature",
-	MIN_TEMPERATURE: "min_temperature",
-	FAN_MODES: "fan_modes",
+  TEMPERATURE_UNIT: 'temperature_unit',
+  TARGET_TEMPERATURE_STEP: 'target_temperature_step',
+  MAX_TEMPERATURE: 'max_temperature',
+  MIN_TEMPERATURE: 'min_temperature',
+  FAN_MODES: 'fan_modes'
 };
 
 class Climate extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.CLIMATE,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.CLIMATE,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`Climate entity created with id: ${this.id}`);
-	}
+    console.debug(`Climate entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Climate;

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -1,80 +1,80 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	OPENING: "OPENING",
-	OPEN: "OPEN",
-	CLOSING: "CLOSING",
-	CLOSED: "CLOSED",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  OPENING: 'OPENING',
+  OPEN: 'OPEN',
+  CLOSING: 'CLOSING',
+  CLOSED: 'CLOSED'
 };
 
 const FEATURES = {
-	OPEN: "open",
-	CLOSE: "close",
-	STOP: "stop",
-	POSITION: "position",
-	TILT: "tilt",
-	TILT_STOP: "tilt_stop",
-	TILT_POSITION: "tilt_position",
+  OPEN: 'open',
+  CLOSE: 'close',
+  STOP: 'stop',
+  POSITION: 'position',
+  TILT: 'tilt',
+  TILT_STOP: 'tilt_stop',
+  TILT_POSITION: 'tilt_position'
 };
 
 const ATTRIBUTES = {
-	STATE: "state",
-	POSITION: "position",
-	TILT_POSITION: "tilt_position",
+  STATE: 'state',
+  POSITION: 'position',
+  TILT_POSITION: 'tilt_position'
 };
 
 const COMMANDS = {
-	OPEN: "open",
-	CLOSE: "close",
-	STOP: "stop",
-	POSITION: "position",
-	TILT: "tilt",
-	TILT_UP: "tilt_up",
-	TILT_DOWN: "tilt_down",
-	TILT_STOP: "tilt_stop",
+  OPEN: 'open',
+  CLOSE: 'close',
+  STOP: 'stop',
+  POSITION: 'position',
+  TILT: 'tilt',
+  TILT_UP: 'tilt_up',
+  TILT_DOWN: 'tilt_down',
+  TILT_STOP: 'tilt_stop'
 };
 
 const DEVICECLASSES = {
-	BLIND: "blind",
-	CURTAIN: "curtain",
-	GARAGE: "garage",
-	SHADE: "shade",
-	DOOR: "door",
-	GATE: "gate",
-	WINDOW: "window",
+  BLIND: 'blind',
+  CURTAIN: 'curtain',
+  GARAGE: 'garage',
+  SHADE: 'shade',
+  DOOR: 'door',
+  GATE: 'gate',
+  WINDOW: 'window'
 };
 
 const OPTIONS = {};
 
 class Cover extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.COVER,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.COVER,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`Cover entity created with id: ${this.id}`);
-	}
+    console.debug(`Cover entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Cover;

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -1,175 +1,170 @@
-"use strict";
+'use strict';
 
-const EventEmitter = require("events");
-const fs = require("fs");
+const EventEmitter = require('events');
+const fs = require('fs');
 
-const Entity = require("./entity");
-const Button = require("./button");
-const Climate = require("./climate");
-const Cover = require("./cover");
-const Light = require("./light");
-const MediaPlayer = require("./media_player");
-const Sensor = require("./sensor");
-const Switch = require("./switch");
+const Entity = require('./entity');
+const Button = require('./button');
+const Climate = require('./climate');
+const Cover = require('./cover');
+const Light = require('./light');
+const MediaPlayer = require('./media_player');
+const Sensor = require('./sensor');
+const Switch = require('./switch');
 
 class Entities extends EventEmitter {
-	#storage;
-	#dataPath;
+  #storage;
+  #dataPath;
 
-	constructor(id) {
-		super();
+  constructor (id) {
+    super();
 
-		this.id = id;
-		this.#storage = {};
-		this.#dataPath = `${this.id}.json`;
+    this.id = id;
+    this.#storage = {};
+    this.#dataPath = `${this.id}.json`;
 
-		// load configuerd entities
-		if (fs.existsSync(this.#dataPath)) {
-			const raw = fs.readFileSync(this.#dataPath);
+    // load configuerd entities
+    if (fs.existsSync(this.#dataPath)) {
+      const raw = fs.readFileSync(this.#dataPath);
 
-			try {
-				this.#storage = JSON.parse(raw);
-				console.log(`ENTITIES(${this.id}): config file loaded.`)
+      try {
+        this.#storage = JSON.parse(raw);
+        console.log(`ENTITIES(${this.id}): config file loaded.`);
+      } catch (e) {
+        console.log(`ENTITIES(${this.id}): Error parsing entities: ${this.#dataPath}`);
+      }
+    } else {
+      console.log(`ENTITIES(${this.id}): No storage file, will create one later: ${this.#dataPath}`);
+    }
+  }
 
-			} catch (e) {
-				console.log(`ENTITIES(${this.id}): Error parsing entities: ${this.#dataPath}`);
-			}
-		} else {
-			console.log(`ENTITIES(${this.id}): No storage file, will create one later: ${this.#dataPath}`)
-		}
-	}
+  static generateId (prefix = 'entity') {
+    return (
+      prefix +
+      '_' +
+      Array(25)
+        .fill()
+        .map(() =>
+          'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.charAt(
+            Math.random() * 62
+          )
+        )
+        .join('')
+    );
+  }
 
-	static generateId(prefix = "entity") {
-		return (
-			prefix +
-			"_" +
-			Array(25)
-				.fill()
-				.map(() =>
-					"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(
-						Math.random() * 62
-					)
-				)
-				.join("")
-		);
-	}
+  contains (id) {
+    return !!this.#storage[id];
+  }
 
-	contains(id) {
-		if (this.#storage[id]) {
-			return true;
-		} else {
-			return false;
-		}
-	}
+  getEntity (id) {
+    if (!this.#storage[id]) {
+      console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
+      return null;
+    }
 
-	getEntity(id) {
-		if (!this.#storage[id]) {
-			console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
-			return null;
-		}
+    return this.#storage[id];
+  }
 
-		return this.#storage[id];
-	}
+  addEntity (entity) {
+    if (this.#storage[entity.id]) {
+      console.log(`ENTITIES(${this.id}): Entity is already in storage: ${entity.id}`);
+      return false;
+    }
+    this.#storage[entity.id] = entity;
 
-	addEntity(entity) {
-		if (this.#storage[entity.id]) {
-			console.log(`ENTITIES(${this.id}): Entity is already in storage: ${entity.id}`);
-			return false;
-		}
-		this.#storage[entity.id] = entity;
+    console.log(`ENTITIES(${this.id}): Entity added: ${entity.id}`);
+    return true;
+  }
 
-		console.log(`ENTITIES(${this.id}): Entity added: ${entity.id}`);
-		return true;
-	}
+  removeEntity (id) {
+    if (!this.#storage[id]) {
+      console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
+      return false;
+    }
 
-	removeEntity(id) {
-		if (!this.#storage[id]) {
-			console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
-			return false;
-		}
+    delete this.#storage[id];
 
-		delete this.#storage[id];
+    console.log(`ENTITIES(${this.id}): Entity removed: ${id}`);
+    return true;
+  }
 
-		console.log(`ENTITIES(${this.id}): Entity removed: ${id}`);
-		return true;
-	}
+  updateEntityAttributes (id, keys, values) {
+    if (!this.contains(id)) {
+      return false;
+    }
 
-	updateEntityAttributes(id, keys, values) {
-		if (!this.contains(id)) {
-			return false;
-		}
+    const updatedData = {};
 
-		let updatedData = {};
+    for (let i = 0; i < keys.length; i++) {
+      if (values[i] !== undefined) {
+        this.#storage[id].attributes[keys[i]] = values[i];
+        updatedData[keys[i]] = values[i];
+      }
+    }
 
-		for (let i = 0; i < keys.length; i++) {
-			if (values[i] != undefined) {
-				this.#storage[id].attributes[keys[i]] = values[i];
-				updatedData[keys[i]] = values[i];
-			}
-		}
+    this.emit(
+      'entity_attributes_updated',
+      id,
+      this.#storage[id].entity_type,
+      updatedData
+    );
 
-		this.emit(
-			"entity_attributes_updated",
-			id,
-			this.#storage[id].entity_type,
-			updatedData
-		);
+    return true;
+  }
 
-		return true;
-	}
+  getEntities () {
+    const entities = [];
 
-	getEntities() {
-		let entities = [];
+    Object.entries(this.#storage).forEach(([, value]) => {
+      const entity = {
+        entity_id: value.id,
+        entity_type: value.entity_type,
+        device_id: value.device_id,
+        features: value.features,
+        name: { en: value.name },
+        area: value.area
+      };
 
-		Object.entries(this.#storage).forEach(([key, value]) => {
-			let entity = {
-				entity_id: value.id,
-				entity_type: value.entity_type,
-				device_id: value.device_id,
-				features: value.features,
-				name: { en: value.name },
-				area: value.area,
-			};
+      entities.push(entity);
+    });
 
-			entities.push(entity);
-		});
+    return entities;
+  }
 
-		return entities;
-	}
+  getStates () {
+    const entities = [];
 
-	getStates() {
-		let entities = [];
+    Object.entries(this.#storage).forEach(([, value]) => {
+      const entity = {
+        entity_id: value.id,
+        entity_type: value.entity_type,
+        device_id: value.device_id,
+        attributes: value.attributes
+      };
 
-		Object.entries(this.#storage).forEach(([key, value]) => {
-			let entity = {
-				entity_id: value.id,
-				entity_type: value.entity_type,
-				device_id: value.device_id,
-				attributes: value.attributes,
-			};
+      entities.push(entity);
+    });
 
-			entities.push(entity);
-		});
+    return entities;
+  }
 
-		return entities;
-	}
+  clear () {
+    this.#storage = {};
+    this.saveData();
+  }
 
-	clear() {
-		this.#storage = {};
-		this.saveData();
-	}
-
-	saveData() {
-		try {
-			fs.writeFileSync(
-				this.#dataPath,
-				JSON.stringify(this.#storage)
-			);
-			console.log(`ENTITIES(${this.id}): Config saved to file: ${this.#dataPath}`);
-		} catch (e) {
-			console.error(`ENTITIES(${this.id}): Error writing config: ${this.#dataPath}`);
-		}
-	}
+  saveData () {
+    try {
+      fs.writeFileSync(
+        this.#dataPath,
+        JSON.stringify(this.#storage)
+      );
+      console.log(`ENTITIES(${this.id}): Config saved to file: ${this.#dataPath}`);
+    } catch (e) {
+      console.error(`ENTITIES(${this.id}): Error writing config: ${this.#dataPath}`);
+    }
+  }
 }
 
 module.exports = Entities;

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -1,37 +1,37 @@
-"use strict";
+'use strict';
 
 const TYPES = {
-	COVER: "cover",
-	BUTTON: "button",
-	CLIMATE: "climate",
-	LIGHT: "light",
-	MEDIA_PLAYER: "media_player",
-	SENSOR: "sensor",
-	SWITCH: "switch",
+  COVER: 'cover',
+  BUTTON: 'button',
+  CLIMATE: 'climate',
+  LIGHT: 'light',
+  MEDIA_PLAYER: 'media_player',
+  SENSOR: 'sensor',
+  SWITCH: 'switch'
 };
 
 class Entity {
-	constructor(
-		id,
-		name,
-		entity_type,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		this.id = id;
-		this.name = name;
-		this.entity_type = entity_type;
-		this.device_id = device_id;
-		this.features = features;
-		this.attributes = attributes;
-		this.device_class = deviceClass;
-		this.options = options;
-		this.area = area;
-	}
+  constructor (
+    id,
+    name,
+    entityType,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    this.id = id;
+    this.name = name;
+    this.entity_type = entityType;
+    this.device_id = deviceId;
+    this.features = features;
+    this.attributes = attributes;
+    this.device_class = deviceClass;
+    this.options = options;
+    this.area = area;
+  }
 }
 
 module.exports = Entity;

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -1,65 +1,65 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	ON: "ON",
-	OFF: "OFF",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  ON: 'ON',
+  OFF: 'OFF'
 };
 
 const FEATURES = {
-	ON_OFF: "on_off",
-	TOGGLE: "toggle",
-	DIM: "dim",
-	COLOR: "color",
-	COLOR_TEMPERATURE: "color_temperature",
+  ON_OFF: 'on_off',
+  TOGGLE: 'toggle',
+  DIM: 'dim',
+  COLOR: 'color',
+  COLOR_TEMPERATURE: 'color_temperature'
 };
 
 const ATTRIBUTES = {
-	STATE: "state",
-	HUE: "hue",
-	SATURATION: "saturation",
-	BRIGHTNESS: "brightness",
-	COLOR_TEMPERATURE: "color_temperature",
+  STATE: 'state',
+  HUE: 'hue',
+  SATURATION: 'saturation',
+  BRIGHTNESS: 'brightness',
+  COLOR_TEMPERATURE: 'color_temperature'
 };
 
 const COMMANDS = {
-	ON: "on",
-	OFF: "off",
-	TOGGLE: "toggle",
+  ON: 'on',
+  OFF: 'off',
+  TOGGLE: 'toggle'
 };
 
 const DEVICECLASSES = {};
 
-const OPTIONS = { COLOR_TEMPERATURE_STEPS: "color_temperature_steps" };
+const OPTIONS = { COLOR_TEMPERATURE_STEPS: 'color_temperature_steps' };
 
 class Light extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.LIGHT,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.LIGHT,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`Light entity created with id: ${this.id}`);
-	}
+    console.debug(`Light entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Light;

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -1,116 +1,116 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	ON: "ON",
-	OFF: "OFF",
-	PLAYING: "PLAYING",
-	PAUSED: "PAUSED",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  ON: 'ON',
+  OFF: 'OFF',
+  PLAYING: 'PLAYING',
+  PAUSED: 'PAUSED'
 };
 
 const FEATURES = {
-	ON_OFF: "on_off",
-	TOGGLE: "toggle",
-	VOLUME: "volume",
-	VOLUME_UP_DOWN: "volume_up_down",
-	MUTE_TOGGLE: "mute_toggle",
-	MUTE: "mute",
-	UNMUTE: "unmute",
-	PLAY_PAUSE: "play_pause",
-	STOP: "stop",
-	NEXT: "next",
-	PREVIOUS: "previous",
-	FAST_FORWARD: "fast_forward",
-	REWIND: "rewind",
-	REPEAT: "repeat",
-	SHUFFLE: "shuffle",
-	SEEK: "seek",
-	MEDIA_DURATION: "media_duration",
-	MEDIA_POSITION: "media_position",
-	MEDIA_TITLE: "media_title",
-	MEDIA_ARTIST: "media_artist",
-	MEDIA_ALBUM: "media_album",
-	MEDIA_IMAGE_URL: "media_image_url",
-	MEDIA_TYPE: "media_type",
-	SOURCE: "source",
-	SOUND_MODE: "sound_mode",
+  ON_OFF: 'on_off',
+  TOGGLE: 'toggle',
+  VOLUME: 'volume',
+  VOLUME_UP_DOWN: 'volume_up_down',
+  MUTE_TOGGLE: 'mute_toggle',
+  MUTE: 'mute',
+  UNMUTE: 'unmute',
+  PLAY_PAUSE: 'play_pause',
+  STOP: 'stop',
+  NEXT: 'next',
+  PREVIOUS: 'previous',
+  FAST_FORWARD: 'fast_forward',
+  REWIND: 'rewind',
+  REPEAT: 'repeat',
+  SHUFFLE: 'shuffle',
+  SEEK: 'seek',
+  MEDIA_DURATION: 'media_duration',
+  MEDIA_POSITION: 'media_position',
+  MEDIA_TITLE: 'media_title',
+  MEDIA_ARTIST: 'media_artist',
+  MEDIA_ALBUM: 'media_album',
+  MEDIA_IMAGE_URL: 'media_image_url',
+  MEDIA_TYPE: 'media_type',
+  SOURCE: 'source',
+  SOUND_MODE: 'sound_mode'
 };
 
 const ATTRIBUTES = {
-	STATE: "state",
-	VOLUME: "volume",
-	MUTED: "muted",
-	MEDIA_DURATION: "media_duration",
-	MEDIA_POSITION: "media_position",
-	MEDIA_TYPE: "media_type",
-	MEDIA_IMAGE_URL: "media_image_url",
-	MEDIA_TITLE: "media_title",
-	MEDIA_ARTIST: "media_artist",
-	MEDIA_ALBUM: "media_album",
-	REPEAT: "repeat",
-	SHUFFLE: "shuffle",
-	SOURCE: "source",
-	SOURCE_LIST: "source_list",
-	SOUND_MODE: "sound_mode",
-	SOUND_MODE_LIST: "sound_mode_list",
+  STATE: 'state',
+  VOLUME: 'volume',
+  MUTED: 'muted',
+  MEDIA_DURATION: 'media_duration',
+  MEDIA_POSITION: 'media_position',
+  MEDIA_TYPE: 'media_type',
+  MEDIA_IMAGE_URL: 'media_image_url',
+  MEDIA_TITLE: 'media_title',
+  MEDIA_ARTIST: 'media_artist',
+  MEDIA_ALBUM: 'media_album',
+  REPEAT: 'repeat',
+  SHUFFLE: 'shuffle',
+  SOURCE: 'source',
+  SOURCE_LIST: 'source_list',
+  SOUND_MODE: 'sound_mode',
+  SOUND_MODE_LIST: 'sound_mode_list'
 };
 
 const COMMANDS = {
-	ON: "on",
-	OFF: "off",
-	TOGGLE: "toggle",
-	PLAY_PAUSE: "play_pause",
-	STOP: "stop",
-	PREVIOUS: "previous",
-	NEXT: "next",
-	FAST_FORWARD: "fast_forward",
-	REWIND: "rewind",
-	SEEK: "seek",
-	VOLUME: "volume",
-	VOLUME_UP: "volume_up",
-	VOLUME_DOWN: "volume_down",
-	MUTE_TOGGLE: "mute_toggle",
-	MUTE: "mute",
-	UNMUTE: "unmute",
-	REPEAT: "repeat",
-	SHUFFLE: "shuffle",
-	SOURCE: "source",
-	SOUND_MODE: "sound_mode",
-	SEARCH: "search",
+  ON: 'on',
+  OFF: 'off',
+  TOGGLE: 'toggle',
+  PLAY_PAUSE: 'play_pause',
+  STOP: 'stop',
+  PREVIOUS: 'previous',
+  NEXT: 'next',
+  FAST_FORWARD: 'fast_forward',
+  REWIND: 'rewind',
+  SEEK: 'seek',
+  VOLUME: 'volume',
+  VOLUME_UP: 'volume_up',
+  VOLUME_DOWN: 'volume_down',
+  MUTE_TOGGLE: 'mute_toggle',
+  MUTE: 'mute',
+  UNMUTE: 'unmute',
+  REPEAT: 'repeat',
+  SHUFFLE: 'shuffle',
+  SOURCE: 'source',
+  SOUND_MODE: 'sound_mode',
+  SEARCH: 'search'
 };
 
-const DEVICECLASSES = { RECEIVER: "receiver", SPEAKER: "speaker" };
+const DEVICECLASSES = { RECEIVER: 'receiver', SPEAKER: 'speaker' };
 
-const OPTIONS = { VOLUME_STEPS: "volume_steps" };
+const OPTIONS = { VOLUME_STEPS: 'volume_steps' };
 
 class MediaPlayer extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.MEDIA_PLAYER,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.MEDIA_PLAYER,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`MediaPlayer entity created with id: ${this.id}`);
-	}
+    console.debug(`MediaPlayer entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = MediaPlayer;

--- a/lib/entities/sensor.js
+++ b/lib/entities/sensor.js
@@ -1,67 +1,67 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	ON: "ON",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  ON: 'ON'
 };
 
 const FEATURES = {};
 
 const ATTRIBUTES = {
-	STATE: "state",
-	VALUE: "value",
-	UNIT: "unit",
+  STATE: 'state',
+  VALUE: 'value',
+  UNIT: 'unit'
 };
 
 const COMMANDS = {};
 
 const DEVICECLASSES = {
-	CUSTOM: "custom",
-	BATTERY: "battery",
-	CURRENT: "current",
-	ENERGY: "energy",
-	HUMIDITY: "humidity",
-	POWER: "power",
-	TEMPERATURE: "temperature",
-	VOLTAGE: "voltage",
+  CUSTOM: 'custom',
+  BATTERY: 'battery',
+  CURRENT: 'current',
+  ENERGY: 'energy',
+  HUMIDITY: 'humidity',
+  POWER: 'power',
+  TEMPERATURE: 'temperature',
+  VOLTAGE: 'voltage'
 };
 
 const OPTIONS = {
-	CUSTOM_UNIT: "custom_unit",
-	NATIVE_UNIT: "native_unit",
-	DECIMALS: "decimals",
-	MIN_VALUE: "min_value",
-	MAX_VALUE: "max_value",
+  CUSTOM_UNIT: 'custom_unit',
+  NATIVE_UNIT: 'native_unit',
+  DECIMALS: 'decimals',
+  MIN_VALUE: 'min_value',
+  MAX_VALUE: 'max_value'
 };
 
 class Sensor extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.SENSOR,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.SENSOR,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`Sensor entity created with id: ${this.id}`);
-	}
+    console.debug(`Sensor entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Sensor;

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -1,61 +1,61 @@
-"use strict";
+'use strict';
 
-const Entity = require("./entity");
+const Entity = require('./entity');
 
 const STATES = {
-	UNAVAILABLE: "UNAVAILABLE",
-	UNKNOWN: "UNKNOWN",
-	ON: "ON",
-	OFF: "OFF",
+  UNAVAILABLE: 'UNAVAILABLE',
+  UNKNOWN: 'UNKNOWN',
+  ON: 'ON',
+  OFF: 'OFF'
 };
 
 const FEATURES = {
-	ON_OFF: "on_off",
-	TOGGLE: "toggle",
+  ON_OFF: 'on_off',
+  TOGGLE: 'toggle'
 };
 
 const ATTRIBUTES = {
-	STATE: "state",
+  STATE: 'state'
 };
 
 const COMMANDS = {
-	ON: "on",
-	OFF: "off",
-	TOGGLE: "toggle",
+  ON: 'on',
+  OFF: 'off',
+  TOGGLE: 'toggle'
 };
 
 const DEVICECLASSES = {
-	OUTLET: "outlet",
-	SWITCH: "switch",
+  OUTLET: 'outlet',
+  SWITCH: 'switch'
 };
 
-const OPTIONS = { READABLE: "readable" };
+const OPTIONS = { READABLE: 'readable' };
 
 class Switch extends Entity {
-	constructor(
-		id,
-		name,
-		device_id,
-		features,
-		attributes,
-		deviceClass,
-		options,
-		area
-	) {
-		super(
-			id,
-			name,
-			Entity.TYPES.SWITCH,
-			device_id,
-			features,
-			attributes,
-			deviceClass,
-			options,
-			area
-		);
+  constructor (
+    id,
+    name,
+    deviceId,
+    features,
+    attributes,
+    deviceClass,
+    options,
+    area
+  ) {
+    super(
+      id,
+      name,
+      Entity.TYPES.SWITCH,
+      deviceId,
+      features,
+      attributes,
+      deviceClass,
+      options,
+      area
+    );
 
-		console.debug(`Switch entity created with id: ${this.id}`);
-	}
+    console.debug(`Switch entity created with id: ${this.id}`);
+  }
 }
 
 module.exports = Switch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,2234 @@
 			"dependencies": {
 				"ws": "^8.8.1"
 			},
-			"devDependencies": {}
+			"devDependencies": {
+				"eslint": "^8.35.0",
+				"eslint-config-semistandard": "^17.0.0",
+				"eslint-config-standard": "^17.0.0",
+				"eslint-plugin-import": "^2.27.5",
+				"eslint-plugin-n": "^15.6.1",
+				"eslint-plugin-promise": "^6.1.1"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+			"integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+			"dev": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.4.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+			"integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+			"dev": true,
+			"dependencies": {
+				"@humanwhocodes/object-schema": "^1.2.1",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/object-schema": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true
+		},
+		"node_modules/acorn": {
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/array-includes": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"get-intrinsic": "^1.1.3",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/builtins": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.0.0"
+			}
+		},
+		"node_modules/builtins/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+			"dev": true,
+			"dependencies": {
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.21.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+			"integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"es-set-tostringtag": "^2.0.1",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
+				"get-intrinsic": "^1.1.3",
+				"get-symbol-description": "^1.0.0",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has": "^1.0.3",
+				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.4",
+				"is-array-buffer": "^3.0.1",
+				"is-callable": "^1.2.7",
+				"is-negative-zero": "^2.0.2",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.10",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.2",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
+				"string.prototype.trimend": "^1.0.6",
+				"string.prototype.trimstart": "^1.0.6",
+				"typed-array-length": "^1.0.4",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3",
+				"has": "^1.0.3",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"dev": true,
+			"dependencies": {
+				"has": "^1.0.3"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+			"integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+			"dev": true,
+			"dependencies": {
+				"@eslint/eslintrc": "^2.0.0",
+				"@eslint/js": "8.35.0",
+				"@humanwhocodes/config-array": "^0.11.8",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^7.1.1",
+				"eslint-utils": "^3.0.0",
+				"eslint-visitor-keys": "^3.3.0",
+				"espree": "^9.4.0",
+				"esquery": "^1.4.2",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"grapheme-splitter": "^1.0.4",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-sdsl": "^4.1.4",
+				"js-yaml": "^4.1.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"regexpp": "^3.2.0",
+				"strip-ansi": "^6.0.1",
+				"strip-json-comments": "^3.1.0",
+				"text-table": "^0.2.0"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-config-semistandard": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-17.0.0.tgz",
+			"integrity": "sha512-tLi0JYmfiiJgtmRhoES55tENatR7y/5aXOh6cBeW+qjzl1+WwyV0arDqR65XN3/xrPZt+/1EG+xNLknV/0jWsQ==",
+			"dev": true,
+			"peerDependencies": {
+				"eslint": "^8.13.0",
+				"eslint-config-standard": "^17.0.0",
+				"eslint-plugin-import": "^2.26.0",
+				"eslint-plugin-n": "^15.0.0",
+				"eslint-plugin-promise": "^6.0.0"
+			}
+		},
+		"node_modules/eslint-config-standard": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+			"integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"peerDependencies": {
+				"eslint": "^8.0.1",
+				"eslint-plugin-import": "^2.25.2",
+				"eslint-plugin-n": "^15.0.0",
+				"eslint-plugin-promise": "^6.0.0"
+			}
+		},
+		"node_modules/eslint-import-resolver-node": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.11.0",
+				"resolve": "^1.22.1"
+			}
+		},
+		"node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-module-utils": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^3.2.7"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-es": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+			"dev": true,
+			"dependencies": {
+				"eslint-utils": "^2.0.0",
+				"regexpp": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=4.19.1"
+			}
+		},
+		"node_modules/eslint-plugin-es/node_modules/eslint-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+			"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslint-plugin-import": {
+			"version": "2.27.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"dev": true,
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"array.prototype.flatmap": "^1.3.1",
+				"debug": "^3.2.7",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.7",
+				"eslint-module-utils": "^2.7.4",
+				"has": "^1.0.3",
+				"is-core-module": "^2.11.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "^3.1.2",
+				"object.values": "^1.1.6",
+				"resolve": "^1.22.1",
+				"semver": "^6.3.0",
+				"tsconfig-paths": "^3.14.1"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-import/node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/eslint-plugin-n": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.1.tgz",
+			"integrity": "sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==",
+			"dev": true,
+			"dependencies": {
+				"builtins": "^5.0.1",
+				"eslint-plugin-es": "^4.1.0",
+				"eslint-utils": "^3.0.0",
+				"ignore": "^5.1.1",
+				"is-core-module": "^2.11.0",
+				"minimatch": "^3.1.2",
+				"resolve": "^1.22.1",
+				"semver": "^7.3.8"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-promise": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+			"integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"engines": {
+				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			},
+			"peerDependencies": {
+				"eslint": ">=5"
+			}
+		},
+		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/espree": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.8.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"dependencies": {
+				"flat-cache": "^3.0.4"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"dev": true,
+			"dependencies": {
+				"flatted": "^3.1.0",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+			"dev": true
+		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+			"integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/globals": {
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.20.2"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+			"integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
+		"node_modules/has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/internal-slot": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.0",
+				"is-typed-array": "^1.1.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"dev": true,
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/js-sdsl": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+			"integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true
+		},
+		"node_modules/json5": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true
+		},
+		"node_modules/object-inspect": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.values": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/regexpp": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mysticatea"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"dev": true,
+			"dependencies": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+			"integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+			"dev": true,
+			"dependencies": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"is-typed-array": "^1.1.9"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+			"dev": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0",
+				"is-typed-array": "^1.1.10"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
 		},
 		"node_modules/ws": {
 			"version": "8.8.1",
@@ -32,14 +2259,1628 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
+		"@eslint/eslintrc": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+			"integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^9.4.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			}
+		},
+		"@eslint/js": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+			"integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+			"dev": true
+		},
+		"@humanwhocodes/config-array": {
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+			"dev": true,
+			"requires": {
+				"@humanwhocodes/object-schema": "^1.2.1",
+				"debug": "^4.1.1",
+				"minimatch": "^3.0.5"
+			}
+		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true
+		},
+		"@humanwhocodes/object-schema": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"dev": true
+		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			}
+		},
+		"@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"requires": {}
+		},
+		"ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"array-includes": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+			"integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"get-intrinsic": "^1.1.3",
+				"is-string": "^1.0.7"
+			}
+		},
+		"array.prototype.flat": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+			"integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
+			}
+		},
+		"array.prototype.flatmap": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+			"integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4",
+				"es-shim-unscopables": "^1.0.0"
+			}
+		},
+		"available-typed-arrays": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"builtins": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"dev": true,
+			"requires": {
+				"semver": "^7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"define-properties": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+			"dev": true,
+			"requires": {
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"es-abstract": {
+			"version": "1.21.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+			"integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"es-set-tostringtag": "^2.0.1",
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
+				"get-intrinsic": "^1.1.3",
+				"get-symbol-description": "^1.0.0",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has": "^1.0.3",
+				"has-property-descriptors": "^1.0.0",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"internal-slot": "^1.0.4",
+				"is-array-buffer": "^3.0.1",
+				"is-callable": "^1.2.7",
+				"is-negative-zero": "^2.0.2",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.2",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.10",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.2",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.4",
+				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
+				"string.prototype.trimend": "^1.0.6",
+				"string.prototype.trimstart": "^1.0.6",
+				"typed-array-length": "^1.0.4",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.9"
+			}
+		},
+		"es-set-tostringtag": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+			"integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.3",
+				"has": "^1.0.3",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"es-shim-unscopables": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+			"integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true
+		},
+		"eslint": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+			"integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+			"dev": true,
+			"requires": {
+				"@eslint/eslintrc": "^2.0.0",
+				"@eslint/js": "8.35.0",
+				"@humanwhocodes/config-array": "^0.11.8",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.3.2",
+				"doctrine": "^3.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^7.1.1",
+				"eslint-utils": "^3.0.0",
+				"eslint-visitor-keys": "^3.3.0",
+				"espree": "^9.4.0",
+				"esquery": "^1.4.2",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"grapheme-splitter": "^1.0.4",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
+				"js-sdsl": "^4.1.4",
+				"js-yaml": "^4.1.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"regexpp": "^3.2.0",
+				"strip-ansi": "^6.0.1",
+				"strip-json-comments": "^3.1.0",
+				"text-table": "^0.2.0"
+			}
+		},
+		"eslint-config-semistandard": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-17.0.0.tgz",
+			"integrity": "sha512-tLi0JYmfiiJgtmRhoES55tENatR7y/5aXOh6cBeW+qjzl1+WwyV0arDqR65XN3/xrPZt+/1EG+xNLknV/0jWsQ==",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-config-standard": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
+			"integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+			"integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.11.0",
+				"resolve": "^1.22.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
+			"integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
+		"eslint-plugin-es": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+			"integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+			"dev": true,
+			"requires": {
+				"eslint-utils": "^2.0.0",
+				"regexpp": "^3.0.0"
+			},
+			"dependencies": {
+				"eslint-utils": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+					"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.27.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+			"integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"array.prototype.flatmap": "^1.3.1",
+				"debug": "^3.2.7",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.7",
+				"eslint-module-utils": "^2.7.4",
+				"has": "^1.0.3",
+				"is-core-module": "^2.11.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "^3.1.2",
+				"object.values": "^1.1.6",
+				"resolve": "^1.22.1",
+				"semver": "^6.3.0",
+				"tsconfig-paths": "^3.14.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				}
+			}
+		},
+		"eslint-plugin-n": {
+			"version": "15.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.6.1.tgz",
+			"integrity": "sha512-R9xw9OtCRxxaxaszTQmQAlPgM+RdGjaL1akWuY/Fv9fRAi8Wj4CUKc6iYVG8QNRjRuo8/BqVYIpfqberJUEacA==",
+			"dev": true,
+			"requires": {
+				"builtins": "^5.0.1",
+				"eslint-plugin-es": "^4.1.0",
+				"eslint-utils": "^3.0.0",
+				"ignore": "^5.1.1",
+				"is-core-module": "^2.11.0",
+				"minimatch": "^3.1.2",
+				"resolve": "^1.22.1",
+				"semver": "^7.3.8"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-promise": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+			"integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+			"dev": true,
+			"requires": {}
+		},
+		"eslint-scope": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			}
+		},
+		"eslint-utils": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"dev": true
+		},
+		"espree": {
+			"version": "9.4.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+			"integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.8.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"esquery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.1.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^5.2.0"
+			}
+		},
+		"estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"fastq": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"file-entry-cache": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^3.0.4"
+			}
+		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"flat-cache": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+			"dev": true,
+			"requires": {
+				"flatted": "^3.1.0",
+				"rimraf": "^3.0.2"
+			}
+		},
+		"flatted": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+			"dev": true
+		},
+		"for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.3"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"function.prototype.name": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
+			}
+		},
+		"functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+			"integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.3"
+			}
+		},
+		"get-symbol-description": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+			"integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.1"
+			}
+		},
+		"glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"requires": {
+				"is-glob": "^4.0.3"
+			}
+		},
+		"globals": {
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.20.2"
+			}
+		},
+		"globalthis": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+			"integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			}
+		},
+		"grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
+		},
+		"has-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+			"integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true
+		},
+		"has-tostringtag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.2"
+			}
+		},
+		"ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"internal-slot": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+			"integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.2.0",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.4"
+			}
+		},
+		"is-array-buffer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.0",
+				"is-typed-array": "^1.1.10"
+			}
+		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-negative-zero": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+			"dev": true
+		},
+		"is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-shared-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.2"
+			}
+		},
+		"is-typed-array": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+			"integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"js-sdsl": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+			"integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1"
+			}
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true
+		},
+		"json5": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true
+		},
+		"object-inspect": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+			"integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
+		"object.assign": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			}
+		},
+		"object.values": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+			"integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optionator": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+			"dev": true,
+			"requires": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
+			}
+		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true
+		},
+		"punycode": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"dev": true
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
+		},
+		"regexp.prototype.flags": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
+			}
+		},
+		"regexpp": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.9.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			}
+		},
+		"semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+			"integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+			"integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.20.4"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"dev": true
+		},
+		"tsconfig-paths": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+			"integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+			"dev": true,
+			"requires": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "^1.2.1"
+			}
+		},
+		"type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true
+		},
+		"typed-array-length": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+			"integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"is-typed-array": "^1.1.9"
+			}
+		},
+		"unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			}
+		},
+		"uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
+		"which-typed-array": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+			"integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+			"dev": true,
+			"requires": {
+				"available-typed-arrays": "^1.0.5",
+				"call-bind": "^1.0.2",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.0",
+				"is-typed-array": "^1.1.10"
+			}
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		},
 		"ws": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
 			"integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
 			"requires": {}
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
 	"dependencies": {
 		"ws": "^8.8.1"
 	},
-	"devDependencies": {},
+	"devDependencies": {
+		"eslint": "^8.35.0",
+		"eslint-config-semistandard": "^17.0.0",
+		"eslint-config-standard": "^17.0.0",
+		"eslint-plugin-import": "^2.27.5",
+		"eslint-plugin-n": "^15.6.1",
+		"eslint-plugin-promise": "^6.1.1"
+	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},


### PR DESCRIPTION
Use ESLint as in web-configurator with `semistandard` but otherwise default rule set.
Include IntelliJ configuration to automatically use ESLint with `fix-on-save`.

Fix ESLint findings and refactor sendResponse:
- Only use default parameter args at the end
- sendOkResult & sendErrorResult helper

Part of #7