### PR TITLE
Initial driver discovery and lots of fixes

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,46 @@
+# ESLint is a tool for identifying and reporting on patterns
+# found in ECMAScript/JavaScript code.
+# More details at https://github.com/eslint/eslint
+# and https://eslint.org
+
+name: ESLint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '26 9 * * 6'
+
+jobs:
+  eslint:
+    name: Run eslint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install ESLint
+        run: |
+          npm install eslint@8.35.0
+          npm install @microsoft/eslint-formatter-sarif@2.1.7
+
+      - name: Run ESLint
+        run: npx eslint .
+          --config .eslintrc.js
+          --ext .js,.jsx,.ts,.tsx
+          --format @microsoft/eslint-formatter-sarif
+          --output-file eslint-results.sarif
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: eslint-results.sarif
+          wait-for-processing: true

--- a/examples/driver.json
+++ b/examples/driver.json
@@ -1,11 +1,11 @@
 {
-	"id": "uc_node_driver",
+	"driver_id": "uc_node_driver",
 	"version": "1.0.0",
 	"min_core_api": "1.0.0",
-	"name": { "en": "My Driver" },
+	"name": { "fr": "Mon driveur", "en": "My Driver", "de": "Mein Treiber", "de-CH": "Min Triber"},
 	"icon": "custom:my_driver_icon",
 	"description": { "en": "Adds support for driver devices." },
-	"driver_url": "ws://localhost:9988",
+	"driver_url": "OPTIONAL: taken from mDNS by the remote if missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
 	"port": "9988",
 	"developer": {
 		"name": "John Doe",

--- a/examples/driver.json
+++ b/examples/driver.json
@@ -4,7 +4,7 @@
 	"min_core_api": "1.0.0",
 	"name": { "fr": "Mon driveur", "en": "My Driver", "de": "Mein Treiber", "de-CH": "Min Triber"},
 	"icon": "custom:my_driver_icon",
-	"description": { "en": "Adds support for driver devices." },
+	"description": { "en": "A simple demo integration with a simulated light entity." },
 	"driver_url": "OPTIONAL: taken from mDNS by the remote if missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
 	"port": "9988",
 	"developer": {

--- a/examples/light.js
+++ b/examples/light.js
@@ -37,6 +37,7 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
 // normally you'd create this where your driver exposed the available entities
 const lightEntity = new uc.Entities.Light(
   'my_unique_light_id',
+  // FIXME name needs to be a proper language string
   'My favorite light',
   uc.getDriverVersion().id,
   [
@@ -60,7 +61,7 @@ uc.on(
   uc.EVENTS.ENTITY_COMMAND,
   async (wsHandle, entityId, entityType, cmdId, params) => {
     console.log(
-            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
+            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${params ? JSON.stringify(params, null, 4) : ''}`
     );
 
     // get the entity from the configured ones
@@ -77,14 +78,16 @@ uc.on(
         if (entity.attributes.state === uc.Entities.Light.STATES.OFF) {
           uc.configuredEntities.updateEntityAttributes(
             entity.id,
-            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-            [uc.Entities.Light.STATES.ON, 255]
+            new Map([
+              [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.ON],
+              [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, 255]])
           );
         } else if (entity.attributes.state === uc.Entities.Light.STATES.ON) {
           uc.configuredEntities.updateEntityAttributes(
             entity.id,
-            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-            [uc.Entities.Light.STATES.OFF, 0]
+            new Map([
+              [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.OFF],
+              [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, 0]])
           );
         }
         break;
@@ -93,15 +96,17 @@ uc.on(
         // A real lamp might store the last brightness value, otherwise the integration could also keep track of the last value.
         uc.configuredEntities.updateEntityAttributes(
           entity.id,
-          [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-          [uc.Entities.Light.STATES.ON, (params && params.brightness) ? params.brightness : 127]
+          new Map([
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.ON],
+            [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, (params && params.brightness) ? params.brightness : 127]])
         );
         break;
       case uc.Entities.Light.COMMANDS.OFF:
         uc.configuredEntities.updateEntityAttributes(
           entity.id,
-          [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-          [uc.Entities.Light.STATES.OFF, 0]
+          new Map([
+            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.OFF],
+            [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, 0]])
         );
         break;
     }

--- a/examples/light.js
+++ b/examples/light.js
@@ -89,19 +89,13 @@ uc.on(
         }
         break;
       case uc.Entities.Light.COMMANDS.ON:
-        if (params.brightness) {
-          uc.configuredEntities.updateEntityAttributes(
-            entity.id,
-            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-            [uc.Entities.Light.STATES.ON, params.brightness]
-          );
-        } else {
-          uc.configuredEntities.updateEntityAttributes(
-            entity.id,
-            [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
-            [uc.Entities.Light.STATES.OFF, 0]
-          );
-        }
+        // params is optional! Use a default if not provided.
+        // A real lamp might store the last brightness value, otherwise the integration could also keep track of the last value.
+        uc.configuredEntities.updateEntityAttributes(
+          entity.id,
+          [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.ATTRIBUTES.BRIGHTNESS],
+          [uc.Entities.Light.STATES.ON, (params && params.brightness) ? params.brightness : 127]
+        );
         break;
       case uc.Entities.Light.COMMANDS.OFF:
         uc.configuredEntities.updateEntityAttributes(

--- a/examples/light.js
+++ b/examples/light.js
@@ -58,9 +58,9 @@ uc.availableEntities.addEntity(lightEntity);
 // and handle the events separately for updating the configured entities
 uc.on(
   uc.EVENTS.ENTITY_COMMAND,
-  async (id, entityId, entityType, cmdId, params) => {
+  async (wsHandle, entityId, entityType, cmdId, params) => {
     console.log(
-            `ENTITY COMMAND: ${id} ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
+            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
     );
 
     // get the entity from the configured ones
@@ -68,7 +68,7 @@ uc.on(
 
     if (entity == null) {
       console.log('Entity not found');
-      await uc.acknowledgeCommand(id, uc.STATUS_CODES.NOT_FOUND);
+      await uc.acknowledgeCommand(wsHandle, uc.STATUS_CODES.NOT_FOUND);
       return;
     }
 
@@ -115,6 +115,6 @@ uc.on(
     // you need to acknowledge if the command was successfully executed
     // we just say OK there, but you need to add logic if the command is
     // really successfully executed on the device
-    await uc.acknowledgeCommand(id);
+    await uc.acknowledgeCommand(wsHandle);
   }
 );

--- a/examples/light.js
+++ b/examples/light.js
@@ -13,41 +13,38 @@ uc.on(uc.EVENTS.DISCONNECT, async () => {
   await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
 });
 
-uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
+uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entityIds) => {
   // the integration will configure entities and subscribe for entity update events
   // the UC library automatically adds the subscribed entities
   // from available to configured
   // you can act on this event if you need for your device handling
-  entities.forEach(entity => {
-    console.log(`Subscribed entity: ${JSON.stringify(entity, null, 4)}`);
+  entityIds.forEach(entityId => {
+    console.log(`Subscribed entity: ${entityId}`);
   });
 });
 
-uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
+uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entityIds) => {
   // when the integration unsubscribed from certain entity updates,
   // the UC library automatically remove the unsubscribed entities
   // from configured
   // you can act on this event if you need for your device handling
-  entities.forEach(entity => {
-    console.log(`Unsubscribed entity: ${JSON.stringify(entity, null, 4)}`);
+  entityIds.forEach(entityId => {
+    console.log(`Unsubscribed entity: ${entityId}`);
   });
 });
 
 // create a light entity
 // normally you'd create this where your driver exposed the available entities
+// The entity name can either be string (which will be mapped to english), or a Map with multiple language entries.
+const name = new Map([['de', 'Mein Lieblingslicht'], ['en', 'My favorite light']]);
 const lightEntity = new uc.Entities.Light(
   'my_unique_light_id',
-  // FIXME name needs to be a proper language string
-  'My favorite light',
-  uc.getDriverVersion().id,
-  [
-    uc.Entities.Light.FEATURES.ON_OFF,
-    uc.Entities.Light.FEATURES.DIM
-  ],
-  {
-    [uc.Entities.Light.ATTRIBUTES.STATE]: uc.Entities.Light.STATES.OFF,
-    [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS]: 0
-  }
+  name,
+  [uc.Entities.Light.FEATURES.ON_OFF, uc.Entities.Light.FEATURES.DIM],
+  new Map([
+    [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.OFF],
+    [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, 0]
+  ])
 );
 
 // add entity as available
@@ -61,7 +58,7 @@ uc.on(
   uc.EVENTS.ENTITY_COMMAND,
   async (wsHandle, entityId, entityType, cmdId, params) => {
     console.log(
-            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${params ? JSON.stringify(params, null, 4) : ''}`
+            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${params ? JSON.stringify(params) : ''}`
     );
 
     // get the entity from the configured ones

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -18,7 +18,7 @@ uc.on(uc.EVENTS.DISCONNECT, async () => {
   await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
 });
 
-uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
+uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entityIds) => {
   // the integration will configure entities and subscribe for entity update events
   // the UC library automatically adds the subscribed entities
   // from available to configured
@@ -27,7 +27,7 @@ uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
   // ...
 });
 
-uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
+uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entityIds) => {
   // when the integration unsubscribed from certain entity updates,
   // the UC library automatically remove the unsubscribed entities
   // from configured
@@ -65,6 +65,7 @@ uc.on(
 // your integration should make entities available for the core
 // 1. create an entity
 const entityId = 'unique-id-inside-integration';
+// The entity name can either be string (which will be mapped to english), or a Map with multiple language entries.
 const entityName = 'My entity';
 
 const entity = new uc.Entities.MediaPlayer(
@@ -72,17 +73,13 @@ const entity = new uc.Entities.MediaPlayer(
   entityId,
   // name of the entity
   entityName,
-  // id of the integration driver
-  uc.getDriverVersion().id,
   // define features in an array. Use the pre-defined object to choose features from
-  [uc.Entities.MediaPlayer.FEATURES.ON_OFF,
-    uc.Entities.MediaPlayer.FEATURES.VOLUME],
+  [uc.Entities.MediaPlayer.FEATURES.ON_OFF, uc.Entities.MediaPlayer.FEATURES.VOLUME],
   // define default attributes for the entity. Use the pre-defined object to choose attributes from
-  {
-    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE]:
-        uc.Entities.MediaPlayer.STATES.OFF,
-    [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME]: 0
-  }
+  new Map([
+    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF],
+    [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME, 0]
+  ])
 );
 
 // 2. add available entity to the core

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -35,9 +35,9 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
 // handle commands coming from the core
 uc.on(
   uc.EVENTS.ENTITY_COMMAND,
-  async (id, entityId, entityType, cmdId, params) => {
+  async (wsHandle, entityId, entityType, cmdId, params) => {
     console.log(
-            `ENTITY COMMAND: ${id} ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
+            `ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`
     );
 
     // handle entity commands here
@@ -48,7 +48,7 @@ uc.on(
     // you need to acknowledge if the command was successfully executed
     // default is uc.STATUS_CODES.OK
     const statusCode = uc.STATUS_CODES.NOT_FOUND;
-    uc.acknowledgeCommand(id, statusCode);
+    uc.acknowledgeCommand(wsHandle, statusCode);
   }
 );
 

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -23,6 +23,8 @@ uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entities) => {
   // the UC library automatically adds the subscribed entities
   // from available to configured
   // you can act on this event if you need for your device handling
+
+  // ...
 });
 
 uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
@@ -30,6 +32,8 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entities) => {
   // the UC library automatically remove the unsubscribed entities
   // from configured
   // you can act on this event if you need for your device handling
+
+  // ...
 });
 
 // handle commands coming from the core
@@ -45,10 +49,12 @@ uc.on(
     // for example start playing a song or change volume
     // Note: you might need to convert values for your desired range and format
 
+    // ...
+
     // you need to acknowledge if the command was successfully executed
     // default is uc.STATUS_CODES.OK
     const statusCode = uc.STATUS_CODES.NOT_FOUND;
-    uc.acknowledgeCommand(wsHandle, statusCode);
+    await uc.acknowledgeCommand(wsHandle, statusCode);
   }
 );
 
@@ -58,6 +64,9 @@ uc.on(
 
 // your integration should make entities available for the core
 // 1. create an entity
+const entityId = 'unique-id-inside-integration';
+const entityName = 'My entity';
+
 const entity = new uc.Entities.MediaPlayer(
   // entity id has to be unique, you can provide it or use uc.Entities.generateId()
   entityId,
@@ -84,20 +93,15 @@ uc.availableEntities.addEntity(entity);
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // when your integration driver needs to update an entity based on a device change
 // keys and values are attribute key and value pairs
-uc.configuredEntities.updateEntityAttributes(entityId, keys, values);
+const attributes = new Map([]);
+uc.configuredEntities.updateEntityAttributes(entityId, attributes);
 
 // for example to update a state fo a media player:
 uc.configuredEntities.updateEntityAttributes(entityId,
-  [uc.Entities.MediaPlayer.ATTRIBUTES.STATE],
-  [uc.Entities.MediaPlayer.STATES.PLAYING]
-);
+  new Map([[uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.PLAYING]]));
 
 // or multiple attributes at the same time
 uc.configuredEntities.updateEntityAttributes(
   entityId,
-  [
-    uc.Entities.MediaPlayer.ATTRIBUTES.STATE,
-    uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST
-  ],
-  [uc.Entities.MediaPlayer.STATES.PLAYING, 'Massive Attack']
-);
+  new Map([[uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.PLAYING],
+    [uc.Entities.MediaPlayer.ATTRIBUTES.MEDIA_ARTIST, 'Massive Attack']]));

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class IntegrationAPI extends EventEmitter {
         const data = {
           entity_id: entityId,
           entity_type: entityType,
-          attributes
+          attributes: Object.fromEntries(attributes)
         };
 
         await this.#sendEvent(uc.EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);

--- a/lib/api_definitions.js
+++ b/lib/api_definitions.js
@@ -26,11 +26,13 @@ const MESSAGES = {
   GET_ENTITY_STATES: 'get_entity_states',
   SUBSCRIBE_EVENTS: 'subscribe_events',
   UNSUBSCRIBE_EVENTS: 'unsubscribe_events',
-  ENTITY_COMMAND: 'entity_command'
+  ENTITY_COMMAND: 'entity_command',
+  GET_DRIVER_METADATA: 'get_driver_metadata'
 };
 
 module.exports.MESSAGES = MESSAGES;
 
+// FIXME split into events and responses
 const EVENTS = {
   // own events
   ENTITY_COMMAND: 'entity_command',
@@ -45,7 +47,8 @@ const EVENTS = {
   DEVICE_STATE: 'device_state',
   AVAILABLE_ENTITIES: 'available_entities',
   ENTITY_STATES: 'entity_states',
-  ENTITY_CHANGE: 'entity_change'
+  ENTITY_CHANGE: 'entity_change',
+  DRIVER_METADATA: 'driver_metadata'
 };
 
 module.exports.EVENTS = EVENTS;

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -2,18 +2,39 @@
 
 const Entity = require('./entity');
 
+/**
+ * Button entity states.
+ *
+ * @type {{AVAILABLE: string, UNAVAILABLE: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   AVAILABLE: 'AVAILABLE'
 };
 
+/**
+ * Button entity attributes.
+ *
+ * @type {{STATE: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'AVAILABLE'
 };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_button.md button entity documentation}
+ * for more information.
+ */
 class Button extends Entity {
-  constructor (id, name, deviceId, area) {
-    super(id, name, Entity.TYPES.BUTTON, deviceId, ['press'], {}, area);
+  /**
+   * Constructs a new button entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.   * @param id
+   * @param {string} area Optional area or room.
+   */
+  constructor (id, name, area = undefined) {
+    super(id, name, Entity.TYPES.BUTTON, ['press'], null, undefined, null, area);
 
     console.debug(`Button entity created with id: ${this.id}`);
   }

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -2,6 +2,11 @@
 
 const Entity = require('./entity');
 
+/**
+ * Climate entity states.
+ *
+ * @type {{HEAT: string, AUTO: string, FAN: string, COOL: string, UNAVAILABLE: string, UNKNOWN: string, OFF: string, HEAT_COOL: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
@@ -13,6 +18,11 @@ const STATES = {
   AUTO: 'AUTO'
 };
 
+/**
+ * Climate entity features.
+ *
+ * @type {{HEAT: string, FAN: string, TARGET_TEMPERATURE: string, CURRENT_TEMPERATURE: string, COOL: string, ON_OFF: string, TARGET_TEMPERATURE_RANGE: string}}
+ */
 const FEATURES = {
   ON_OFF: 'on_off',
   HEAT: 'heat',
@@ -23,6 +33,11 @@ const FEATURES = {
   FAN: 'fan'
 };
 
+/**
+ * Climate entity attributes.
+ *
+ * @type {{TARGET_TEMPERATURE: string, CURRENT_TEMPERATURE: string, STATE: string, TARGET_TEMPERATURE_HIGH: string, TARGET_TEMPERATURE_LOW: string, FAN_MODE: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state',
   CURRENT_TEMPERATURE: 'current_temperature',
@@ -32,6 +47,11 @@ const ATTRIBUTES = {
   FAN_MODE: 'fan_mode'
 };
 
+/**
+ * Climate entity commands.
+ *
+ * @type {{TARGET_TEMPERATURE: string, OFF: string, HVAC_MODE: string, TARGET_TEMPERATURE_RANGE: string, ON: string, FAN_MODE: string}}
+ */
 const COMMANDS = {
   ON: 'on',
   OFF: 'off',
@@ -41,8 +61,18 @@ const COMMANDS = {
   FAN_MODE: 'fan_mode'
 };
 
+/**
+ * Climate entity device classes.
+ *
+ * @type {{}}
+ */
 const DEVICECLASSES = {};
 
+/**
+ * Climate entity options.
+ *
+ * @type {{MIN_TEMPERATURE: string, TARGET_TEMPERATURE_STEP: string, FAN_MODES: string, TEMPERATURE_UNIT: string, MAX_TEMPERATURE: string}}
+ */
 const OPTIONS = {
   TEMPERATURE_UNIT: 'temperature_unit',
   TARGET_TEMPERATURE_STEP: 'target_temperature_step',
@@ -51,22 +81,35 @@ const OPTIONS = {
   FAN_MODES: 'fan_modes'
 };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_climate.md climate entity documentation}
+ * for more information.
+ */
 class Climate extends Entity {
+  /**
+   * Constructs a new climate entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.CLIMATE,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -2,6 +2,11 @@
 
 const Entity = require('./entity');
 
+/**
+ * Cover entity states.
+ *
+ * @type {{CLOSING: string, CLOSED: string, OPENING: string, UNAVAILABLE: string, UNKNOWN: string, OPEN: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
@@ -11,6 +16,11 @@ const STATES = {
   CLOSED: 'CLOSED'
 };
 
+/**
+ * Cover entity features.
+ *
+ * @type {{POSITION: string, STOP: string, TILT_STOP: string, TILT_POSITION: string, TILT: string, CLOSE: string, OPEN: string}}
+ */
 const FEATURES = {
   OPEN: 'open',
   CLOSE: 'close',
@@ -21,12 +31,22 @@ const FEATURES = {
   TILT_POSITION: 'tilt_position'
 };
 
+/**
+ * Cover entity attributes.
+ *
+ * @type {{POSITION: string, STATE: string, TILT_POSITION: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state',
   POSITION: 'position',
   TILT_POSITION: 'tilt_position'
 };
 
+/**
+ * Cover entity commands.
+ *
+ * @type {{POSITION: string, TILT_DOWN: string, STOP: string, TILT_STOP: string, TILT: string, CLOSE: string, TILT_UP: string, OPEN: string}}
+ */
 const COMMANDS = {
   OPEN: 'open',
   CLOSE: 'close',
@@ -38,6 +58,11 @@ const COMMANDS = {
   TILT_STOP: 'tilt_stop'
 };
 
+/**
+ * Cover entity device classes.
+ *
+ * @type {{BLIND: string, GARAGE: string, CURTAIN: string, GATE: string, SHADE: string, DOOR: string, WINDOW: string}}
+ */
 const DEVICECLASSES = {
   BLIND: 'blind',
   CURTAIN: 'curtain',
@@ -48,24 +73,42 @@ const DEVICECLASSES = {
   WINDOW: 'window'
 };
 
+/**
+ * Cover entity options.
+ *
+ * @type {{}}
+ */
 const OPTIONS = {};
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_cover.md cover entity documentation}
+ * for more information.
+ */
 class Cover extends Entity {
+  /**
+   * Constructs a new cover entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.COVER,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -122,8 +122,7 @@ class Entities extends EventEmitter {
         entity_type: value.entity_type,
         device_id: value.device_id,
         features: value.features,
-        // FIXME this needs to be a proper language string
-        name: { en: value.name },
+        name: value.name,
         area: value.area
       };
 

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -23,7 +23,7 @@ class Entities extends EventEmitter {
     this.#storage = {};
     this.#dataPath = `${this.id}.json`;
 
-    // load configuerd entities
+    // load configured entities
     if (fs.existsSync(this.#dataPath)) {
       const raw = fs.readFileSync(this.#dataPath);
 
@@ -89,6 +89,7 @@ class Entities extends EventEmitter {
     return true;
   }
 
+  // FIXME don't use separate keys & values, use a proper map instead
   updateEntityAttributes (id, keys, values) {
     if (!this.contains(id)) {
       return false;

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -89,26 +89,25 @@ class Entities extends EventEmitter {
     return true;
   }
 
-  // FIXME don't use separate keys & values, use a proper map instead
-  updateEntityAttributes (id, keys, values) {
+  /**
+   * Update or merge the provided attributes into an entity.
+   *
+   * @param {String} id The entity_id
+   * @param {Map} attributes The attributes to merge into the entity's attributes
+   * @returns {boolean} false if entity doesn't exist, true if attributes were merged.
+   */
+  updateEntityAttributes (id, attributes) {
     if (!this.contains(id)) {
       return false;
     }
 
-    const updatedData = {};
-
-    for (let i = 0; i < keys.length; i++) {
-      if (values[i] !== undefined) {
-        this.#storage[id].attributes[keys[i]] = values[i];
-        updatedData[keys[i]] = values[i];
-      }
-    }
+    attributes.forEach((value, key) => { this.#storage[id].attributes[key] = value; });
 
     this.emit(
       'entity_attributes_updated',
       id,
       this.#storage[id].entity_type,
-      updatedData
+      attributes
     );
 
     return true;
@@ -123,6 +122,7 @@ class Entities extends EventEmitter {
         entity_type: value.entity_type,
         device_id: value.device_id,
         features: value.features,
+        // FIXME this needs to be a proper language string
         name: { en: value.name },
         area: value.area
       };

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * Available entity types.
+ *
+ * @type {{COVER: string, BUTTON: string, LIGHT: string, SENSOR: string, MEDIA_PLAYER: string, SWITCH: string, CLIMATE: string}}
+ */
 const TYPES = {
   COVER: 'cover',
   BUTTON: 'button',
@@ -11,11 +16,22 @@ const TYPES = {
 };
 
 class Entity {
+  /**
+   * Constructs a new entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string} entityType One of defined [Entity.TYPES]{@link TYPES}.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
     entityType,
-    deviceId,
     features,
     attributes,
     deviceClass,
@@ -23,11 +39,11 @@ class Entity {
     area
   ) {
     this.id = id;
-    this.name = name;
+    this.name = (typeof name === 'string' || name instanceof String) ? { en: name } : Object.fromEntries(name);
     this.entity_type = entityType;
-    this.device_id = deviceId;
+    this.device_id = null; // not yet supported
     this.features = features;
-    this.attributes = attributes;
+    this.attributes = attributes ? Object.fromEntries(attributes) : null;
     this.device_class = deviceClass;
     this.options = options;
     this.area = area;

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -2,6 +2,11 @@
 
 const Entity = require('./entity');
 
+/**
+ * Light entity states.
+ *
+ * @type {{UNAVAILABLE: string, UNKNOWN: string, OFF: string, ON: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
@@ -9,6 +14,11 @@ const STATES = {
   OFF: 'OFF'
 };
 
+/**
+ * Light entity features.
+ *
+ * @type {{TOGGLE: string, COLOR: string, ON_OFF: string, DIM: string, COLOR_TEMPERATURE: string}}
+ */
 const FEATURES = {
   ON_OFF: 'on_off',
   TOGGLE: 'toggle',
@@ -17,6 +27,11 @@ const FEATURES = {
   COLOR_TEMPERATURE: 'color_temperature'
 };
 
+/**
+ * Light entity attributes.
+ *
+ * @type {{STATE: string, HUE: string, COLOR_TEMPERATURE: string, BRIGHTNESS: string, SATURATION: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state',
   HUE: 'hue',
@@ -25,32 +40,59 @@ const ATTRIBUTES = {
   COLOR_TEMPERATURE: 'color_temperature'
 };
 
+/**
+ * Light entity commands.
+ *
+ * @type {{TOGGLE: string, OFF: string, ON: string}}
+ */
 const COMMANDS = {
   ON: 'on',
   OFF: 'off',
   TOGGLE: 'toggle'
 };
 
+/**
+ * Light entity device classes.
+ * @type {{}}
+ */
 const DEVICECLASSES = {};
 
+/**
+ * Light entity options.
+ *
+ * @type {{COLOR_TEMPERATURE_STEPS: string}}
+ */
 const OPTIONS = { COLOR_TEMPERATURE_STEPS: 'color_temperature_steps' };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_light.md light entity documentation}
+ * for more information.
+ */
 class Light extends Entity {
+  /**
+   * Constructs a new light entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.LIGHT,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -2,6 +2,11 @@
 
 const Entity = require('./entity');
 
+/**
+ * Media-player entity states.
+ *
+ * @type {{PAUSED: string, UNAVAILABLE: string, UNKNOWN: string, OFF: string, PLAYING: string, ON: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
@@ -11,6 +16,11 @@ const STATES = {
   PAUSED: 'PAUSED'
 };
 
+/**
+ * Media-player entity features.
+ *
+ * @type {{REPEAT: string, TOGGLE: string, UNMUTE: string, SHUFFLE: string, MEDIA_DURATION: string, PREVIOUS: string, MEDIA_ALBUM: string, PLAY_PAUSE: string, NEXT: string, MEDIA_TYPE: string, REWIND: string, SEEK: string, VOLUME_UP_DOWN: string, STOP: string, FAST_FORWARD: string, VOLUME: string, MEDIA_ARTIST: string, ON_OFF: string, MUTE_TOGGLE: string, MEDIA_TITLE: string, MEDIA_IMAGE_URL: string, SOUND_MODE: string, MEDIA_POSITION: string, SOURCE: string, MUTE: string}}
+ */
 const FEATURES = {
   ON_OFF: 'on_off',
   TOGGLE: 'toggle',
@@ -39,6 +49,11 @@ const FEATURES = {
   SOUND_MODE: 'sound_mode'
 };
 
+/**
+ * Media-player entity attributes.
+ *
+ * @type {{REPEAT: string, SOURCE_LIST: string, VOLUME: string, SOUND_MODE_LIST: string, MEDIA_ARTIST: string, STATE: string, SHUFFLE: string, MEDIA_DURATION: string, MUTED: string, MEDIA_TITLE: string, MEDIA_IMAGE_URL: string, SOUND_MODE: string, MEDIA_POSITION: string, MEDIA_ALBUM: string, MEDIA_TYPE: string, SOURCE: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state',
   VOLUME: 'volume',
@@ -58,6 +73,11 @@ const ATTRIBUTES = {
   SOUND_MODE_LIST: 'sound_mode_list'
 };
 
+/**
+ * Media-player entity commands.
+ *
+ * @type {{REPEAT: string, TOGGLE: string, STOP: string, FAST_FORWARD: string, SEARCH: string, VOLUME: string, MUTE_TOGGLE: string, UNMUTE: string, SHUFFLE: string, VOLUME_DOWN: string, OFF: string, PREVIOUS: string, SOUND_MODE: string, PLAY_PAUSE: string, NEXT: string, SOURCE: string, REWIND: string, VOLUME_UP: string, MUTE: string, SEEK: string, ON: string}}
+ */
 const COMMANDS = {
   ON: 'on',
   OFF: 'off',
@@ -82,26 +102,49 @@ const COMMANDS = {
   SEARCH: 'search'
 };
 
+/**
+ * Media-player entity device classes.
+ *
+ * @type {{SPEAKER: string, RECEIVER: string}}
+ */
 const DEVICECLASSES = { RECEIVER: 'receiver', SPEAKER: 'speaker' };
 
+/**
+ * Media-player entity options.
+ *
+ * @type {{VOLUME_STEPS: string}}
+ */
 const OPTIONS = { VOLUME_STEPS: 'volume_steps' };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_media_player.md media-player entity documentation}
+ * for more information.
+ */
 class MediaPlayer extends Entity {
+  /**
+   * Constructs a new media-player entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.MEDIA_PLAYER,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/lib/entities/sensor.js
+++ b/lib/entities/sensor.js
@@ -2,22 +2,47 @@
 
 const Entity = require('./entity');
 
+/**
+ * Sensor entity states.
+ *
+ * @type {{UNAVAILABLE: string, UNKNOWN: string, ON: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
   ON: 'ON'
 };
 
+/**
+ * Sensor entity features.
+ *
+ * @type {{}}
+ */
 const FEATURES = {};
 
+/**
+ * Sensor entity attributes.
+ *
+ * @type {{UNIT: string, STATE: string, VALUE: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state',
   VALUE: 'value',
   UNIT: 'unit'
 };
 
+/**
+ * Sensor entity commands.
+ *
+ * @type {{}}
+ */
 const COMMANDS = {};
 
+/**
+ * Sensor entity device classes.
+ *
+ * @type {{BATTERY: string, ENERGY: string, VOLTAGE: string, HUMIDITY: string, TEMPERATURE: string, CUSTOM: string, POWER: string, CURRENT: string}}
+ */
 const DEVICECLASSES = {
   CUSTOM: 'custom',
   BATTERY: 'battery',
@@ -29,6 +54,11 @@ const DEVICECLASSES = {
   VOLTAGE: 'voltage'
 };
 
+/**
+ * Sensor entity options.
+ *
+ * @type {{CUSTOM_UNIT: string, DECIMALS: string, NATIVE_UNIT: string, MAX_VALUE: string, MIN_VALUE: string}}
+ */
 const OPTIONS = {
   CUSTOM_UNIT: 'custom_unit',
   NATIVE_UNIT: 'native_unit',
@@ -37,22 +67,35 @@ const OPTIONS = {
   MAX_VALUE: 'max_value'
 };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_sensor.md sensor entity documentation}
+ * for more information.
+ */
 class Sensor extends Entity {
+  /**
+   * Constructs a new sensor entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.SENSOR,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -2,6 +2,11 @@
 
 const Entity = require('./entity');
 
+/**
+ * Switch entity states.
+ *
+ * @type {{UNAVAILABLE: string, UNKNOWN: string, OFF: string, ON: string}}
+ */
 const STATES = {
   UNAVAILABLE: 'UNAVAILABLE',
   UNKNOWN: 'UNKNOWN',
@@ -9,44 +14,82 @@ const STATES = {
   OFF: 'OFF'
 };
 
+/**
+ * Switch entity features.
+ *
+ * @type {{TOGGLE: string, ON_OFF: string}}
+ */
 const FEATURES = {
   ON_OFF: 'on_off',
   TOGGLE: 'toggle'
 };
 
+/**
+ * Switch entity attributes.
+ *
+ * @type {{STATE: string}}
+ */
 const ATTRIBUTES = {
   STATE: 'state'
 };
 
+/**
+ * Switch entity commands.
+ *
+ * @type {{TOGGLE: string, OFF: string, ON: string}}
+ */
 const COMMANDS = {
   ON: 'on',
   OFF: 'off',
   TOGGLE: 'toggle'
 };
 
+/**
+ * Switch entity device classes.
+ *
+ * @type {{SWITCH: string, OUTLET: string}}
+ */
 const DEVICECLASSES = {
   OUTLET: 'outlet',
   SWITCH: 'switch'
 };
 
+/**
+ * Switch entity options.
+ *
+ * @type {{READABLE: string}}
+ */
 const OPTIONS = { READABLE: 'readable' };
 
+/**
+ * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_switch.md switch entity documentation}
+ * for more information.
+ */
 class Switch extends Entity {
+  /**
+   * Constructs a new switch entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string[]} features Optional entity features.
+   * @param {Map} attributes Optional entity attribute Map holding the current state.
+   * @param {string} deviceClass Optional device class.
+   * @param {object} options Further options. See entity documentation.
+   * @param {string} area Optional area or room.
+   */
   constructor (
     id,
     name,
-    deviceId,
     features,
     attributes,
-    deviceClass,
-    options,
-    area
+    deviceClass = undefined,
+    options = null,
+    area = undefined
   ) {
     super(
       id,
       name,
       Entity.TYPES.SWITCH,
-      deviceId,
       features,
       attributes,
       deviceClass,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.5",
 			"license": "ISC",
 			"dependencies": {
+				"bonjour-service": "^1.1.0",
 				"ws": "^8.8.1"
 			},
 			"devDependencies": {
@@ -84,6 +85,11 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
+		},
+		"node_modules/@leichtgewicht/ip-codec": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -193,6 +199,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/array-flatten": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+		},
 		"node_modules/array-includes": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
@@ -265,6 +276,17 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
+		},
+		"node_modules/bonjour-service": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
+			"integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
+			"dependencies": {
+				"array-flatten": "^2.1.2",
+				"dns-equal": "^1.0.0",
+				"fast-deep-equal": "^3.1.3",
+				"multicast-dns": "^7.2.5"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -413,6 +435,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
+		},
+		"node_modules/dns-packet": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+			"dependencies": {
+				"@leichtgewicht/ip-codec": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/doctrine": {
@@ -924,8 +962,7 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -1650,6 +1687,18 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/multicast-dns": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+			"integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+			"dependencies": {
+				"dns-packet": "^5.2.2",
+				"thunky": "^1.0.2"
+			},
+			"bin": {
+				"multicast-dns": "cli.js"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2100,6 +2149,11 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
+		"node_modules/thunky": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -2326,6 +2380,11 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@leichtgewicht/ip-codec": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2404,6 +2463,11 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"array-flatten": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+		},
 		"array-includes": {
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
@@ -2452,6 +2516,17 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
+		},
+		"bonjour-service": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
+			"integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
+			"requires": {
+				"array-flatten": "^2.1.2",
+				"dns-equal": "^1.0.0",
+				"fast-deep-equal": "^3.1.3",
+				"multicast-dns": "^7.2.5"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -2564,6 +2639,19 @@
 			"requires": {
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
+			}
+		},
+		"dns-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+			"integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
+		},
+		"dns-packet": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+			"integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+			"requires": {
+				"@leichtgewicht/ip-codec": "^2.0.1"
 			}
 		},
 		"doctrine": {
@@ -2938,8 +3026,7 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -3459,6 +3546,15 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"multicast-dns": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+			"integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+			"requires": {
+				"dns-packet": "^5.2.2",
+				"thunky": "^1.0.2"
+			}
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3756,6 +3852,11 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
+		},
+		"thunky": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
 		},
 		"tsconfig-paths": {
 			"version": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"lib": "lib"
 	},
 	"dependencies": {
+		"bonjour-service": "^1.1.0",
 		"ws": "^8.8.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This PR adds the initial functionality for integration driver discovery:
- Announce integration driver with mDNS
- Handle new `get_driver_metadata` message
The next remote-core release will support integration driver discovery and creation with the web-configurator. The integration setup flow will follow next.

Furthermore, this PR fixes a few things, adds initial JSDoc and a bit more types, e.g. a Map for entity attributes instead of an object.
As a non-JS developer I just can't handle all this untyped stuff 😄 Time for TS!

- Fix WebSocket connection handling to allow multiple clients. This fixes #6  
  The logic for multiple clients is kept very simple, but allows to test with a real device and a developer console.
  - Multiple clients share the same configured entities.
  - Events are sent to all connected clients.
- Ignore already subscribed entities and don't return an error to the client. This fixes #2
- Enforce ESLint with GitHub action. This closes #7
- Removed invalid deviceId handling.
