### PR TITLE
Add initial driver discovery and setup flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,4 @@ dist
 .tern-port
 lib/.DS_Store
 .DS_Store
-examples/configured.json
+configured.json

--- a/.idea/runConfigurations/light_js.xml
+++ b/.idea/runConfigurations/light_js.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="light.js" type="NodeJSConfigurationType" nameIsGenerated="true" path-to-js-file="light.js" working-dir="$PROJECT_DIR$/examples">
+  <configuration default="false" name="light.js" type="NodeJSConfigurationType" nameIsGenerated="true" path-to-js-file="light.js" working-dir="$PROJECT_DIR$/examples/simulated-light/">
     <method v="2" />
   </configuration>
 </component>

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 This is a NodeJS library that can be used for NodeJS based integrations. It wraps the UC Integration API.
 
-It's a pre-alpha release. Missing features will be added continously.
+It's a pre-alpha release. Missing features will be added continuously.
 
 Not supported:
 
--   secure WebSocket
--   multi-device integration
--   setup flow
+- secure WebSocket
 
 ---
 
 ### Usage
 
-Look into `examples` for some pointers.
+Look into [examples](examples) for some pointers.

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,7 +55,7 @@ web-configurator or manually through the Core-API.
 
 ### mDNS advertisement & auto-discovery
 
-The integration library advertises the driver over mDNS. See [mDNS advertisement](https://github.com/unfoldedcircle/core-api/blob/driver-discovery/doc/integration-driver/driver-advertisement.md)
+The integration library advertises the driver over mDNS. See [mDNS advertisement](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-advertisement.md)
 in the Core-API documentation.
 
 - The `driver_id` value in `driver.json` is used as instance name and must be unique.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,26 +1,68 @@
-# Minimal one light integration example
+# Integration Driver Examples
 
-This example creates one light entity and makes it available.
-It handles basic commands sent from the `remote-core`.
+## Minimum required driver framework
 
-You can check `minimum-required.js` for the minimum required methods and events that needs to be handled in an integration.
+The `minimum-required.js` file contains the minimum required methods and events that needs to be handled in an
+integration driver.
 
-### Configuring
+- The driver can be discovered and registered in the web-configurator. 
+- It exposes a media-player entity.
+- There are no implemented entity commands, only a stub handler where the commands have to be implemented.
 
-Edit `driver.json` if you'd like to change the port or any other information.
 
-The `icon` needs to be uploaded to the `remote-core` (via the Web Configurator or API) and referenced by its id.
+## simulated-light
 
-### Running the app
+Simple one light integration example with a driver setup flow.
+
+This example creates one simulated light entity and handles basic commands sent from the `remote-core`.
 
 ```shell
+cd simulated-light
 npm install
 node light.js
 ```
 
-### Registering the integration
+## Driver configuration
 
-Before the `remote-core` can talk to the integration, it needs to be registered.
+Edit `driver.json` if you'd like to change the port or any other information.
+
+- See `driverMetadata` object in the [Integration-API specification](https://github.com/unfoldedcircle/core-api/tree/main/integration-api)
+  for all configuration options.
+  - ⚠️ This library requires the additional property `port` to configure the WebSocket server port and is not part of
+       the `driverMetadata` object. 
+- If an `icon` is specified in `driver.json`, it needs to be uploaded to the `remote-core` (via the Web Configurator
+  or REST Core-API) and referenced by its id.
+- The `driver_url` property is optional and offers different behaviour:
+  - if specified and value either starts with `ws://` or `wss://`, the given address is used by the remote to connect
+    to the driver.
+  - if specified and not starting with a WebSocket schema, the library replaces the URL with the hostname and configured
+    port. The resulting URL is used by the remote to connect to the driver.
+  - if missing, the remote determines the driver URL by the published mDNS data.
+    - If the machine running the integration driver has multiple network interfaces, the first address is used, which
+      could be random!
+  - While configuring an integration driver, the user can also override the driver address. 
+- The `setup_data_schema` property enables the driver setup flow to configure the driver during registration.
+  - The first request sent is `setup_driver` containing the provided input values (if there are input fields).  
+    This triggers the `uc.EVENTS.SETUP_DRIVER` event in the library which the integration driver has to acknowledge.
+  - From there on, the integration driver needs to send `driver_setup_change` messages with the setup status, or user
+    input requests. This is handled with calling `uc.driverSetupProgress` and `uc.requestDriverSetupUserConfirmation`.
+  - See [simulated-light/light.js](simulated-light/light.js) for an example and the [Integration-API documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/integration-driver).
+
+## Driver registration
+
+Before the `remote-core` can talk to the integration, it needs to be registered. Either through auto-discovery with the
+web-configurator or manually through the Core-API.
+
+### mDNS advertisement & auto-discovery
+
+The integration library advertises the driver over mDNS. See [mDNS advertisement](https://github.com/unfoldedcircle/core-api/blob/driver-discovery/doc/integration-driver/driver-advertisement.md)
+in the Core-API documentation.
+
+- The `driver_id` value in `driver.json` is used as instance name and must be unique.
+- Use the web-configurator to discover the driver in "Integration & docks"
+
+### Manual registration with Core-API
+
 
 You can do it via the REST or WebSocket API, by sending the following requests.
 Make sure to use the same information as you've defined in `driver.json`.
@@ -28,7 +70,7 @@ Make sure to use the same information as you've defined in `driver.json`.
 Edit the curl commands to add your preferred authentication (basic auth or api key).
 You can find the documentation here: [https://github.com/unfoldedcircle/core-simulator](https://github.com/unfoldedcircle/core-simulator)
 
-### Register the driver
+#### Register the driver
 
 Rest:
 
@@ -40,23 +82,22 @@ curl -X 'POST' \
   -d '{
         "driver_id": "uc_node_driver",
         "name": {
-            "en": "My Driver"
+          "en": "My Driver"
         },
         "driver_url": "ws://localhost:9988",
         "version": "1.0.0",
         "enabled": true,
         "icon": "custom:my_driver_icon",
         "description": {
-            "en": "Adds support for driver devices."
+          "en": "Adds support for driver devices."
         },
         "developer": {
-		"name": "John Doe",
-		"email": "john@doe.com",
-		"url": "https://www.unfoldedcircle.com/support"
+          "name": "John Doe",
+          "email": "john@doe.com",
+          "url": "https://www.unfoldedcircle.com/support"
         },
         "home_page": "https://www.unfoldedcircle.com",
-        "release_date": "2023-03-03",
-        "device_discovery": false
+        "release_date": "2023-03-03"
 }'
 ```
 
@@ -70,28 +111,27 @@ WebSocket:
     "msg_data": {
         "driver_id": "uc_node_driver",
         "name": {
-            "en": "My Driver"
+          "en": "My Driver"
         },
         "driver_url": "ws://localhost:9988",
         "version": "1.0.0",
         "enabled": true,
         "icon": "custom:my_driver_icon",
         "description": {
-            "en": "Adds support for driver devices."
+          "en": "Adds support for driver devices."
         },
         "developer": {
-		"name": "John Doe",
-		"email": "john@doe.com",
-		"url": "https://www.unfoldedcircle.com/support"
+          "name": "John Doe",
+          "email": "john@doe.com",
+          "url": "https://www.unfoldedcircle.com/support"
         },
         "home_page": "https://www.unfoldedcircle.com",
-        "release_date": "2023-03-03",
-        "device_discovery": false
+        "release_date": "2023-03-03"
     }
 }
 ```
 
-### Create an integration instance
+#### Create an integration instance
 
 Rest:
 
@@ -127,6 +167,10 @@ WebSocket:
 }
 ```
 
-### Delete the integration instance
+### Delete the integration
 
 Easiest way to do this is to use the Web Configurator.
+
+If the integration has been configured, the first delete operation in the "Integrations & dock" view will remove the
+integration instance (which provides the available entities), the second delete will also remove the driver
+configuration. 

--- a/examples/driver.json
+++ b/examples/driver.json
@@ -1,17 +1,9 @@
 {
-	"driver_id": "uc_node_driver",
-	"version": "1.0.0",
-	"min_core_api": "1.0.0",
-	"name": { "fr": "Mon driveur", "en": "My Driver", "de": "Mein Treiber", "de-CH": "Min Triber"},
-	"icon": "custom:my_driver_icon",
-	"description": { "en": "A simple demo integration with a simulated light entity." },
-	"#driver_url": "OPTIONAL: the remote uses the driver URL from mDNS if `driver_url` is missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
-	"port": "9988",
+	"driver_id": "minimal_driver",
+	"version": "0.0.1",
+	"name": { "en": "Minimal driver" },
+	"port": "1946",
 	"developer": {
-		"name": "John Doe",
-		"email": "john@doe.com",
-		"url": "https://www.unfoldedcircle.com"
-	},
-	"home_page": "https://www.unfoldedcircle.com",
-	"release_date": "2023-03-03"
+		"name": "Jane Doe"
+	}
 }

--- a/examples/driver.json
+++ b/examples/driver.json
@@ -5,7 +5,7 @@
 	"name": { "fr": "Mon driveur", "en": "My Driver", "de": "Mein Treiber", "de-CH": "Min Triber"},
 	"icon": "custom:my_driver_icon",
 	"description": { "en": "A simple demo integration with a simulated light entity." },
-	"driver_url": "OPTIONAL: taken from mDNS by the remote if missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
+	"#driver_url": "OPTIONAL: the remote uses the driver URL from mDNS if `driver_url` is missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
 	"port": "9988",
 	"developer": {
 		"name": "John Doe",

--- a/examples/light.js
+++ b/examples/light.js
@@ -33,6 +33,56 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entityIds) => {
   });
 });
 
+uc.on(uc.EVENTS.SETUP_DRIVER, async (wsHandle, setupData) => {
+  console.log(`Setting up driver. Setup data: ${setupData}`);
+  // do any initial checks here
+  // ...
+  await new Promise(resolve => setTimeout(resolve, 300));
+
+  // all good: confirm request. This will start the setup flow
+  await uc.acknowledgeCommand(wsHandle);
+  console.log('Acknowledged driver setup');
+
+  // implement interactive setup flow, this is just a simulated example
+  // ...
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  console.log('Sending setup progress that we are still busy...');
+  await uc.driverSetupProgress(wsHandle);
+
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  console.log('Requesting user confirmation to finish setup...');
+  await uc.requestDriverSetupUserConfirmation(wsHandle, 'Please confirm driver setup');
+});
+
+uc.on(uc.EVENTS.SETUP_DRIVER_USER_DATA, async (wsHandle, userData) => {
+  console.log(`Received user input for driver setup: ${userData}`);
+
+  // implement interactive setup flow, this is just a simulated example
+  // ...
+
+  // Not expected, send error response
+  await uc.acknowledgeCommand(wsHandle, uc.STATUS_CODES.BAD_REQUEST);
+});
+
+uc.on(uc.EVENTS.SETUP_DRIVER_USER_CONFIRMATION, async (wsHandle) => {
+  console.log('Received user confirmation for driver setup: sending OK');
+  await uc.acknowledgeCommand(wsHandle);
+
+  // implement interactive setup flow, this is just a simulated example
+  // ...
+  await new Promise(resolve => setTimeout(resolve, 700));
+
+  console.log('Sending setup progress that we are still busy...');
+  await uc.driverSetupProgress(wsHandle);
+
+  await new Promise(resolve => setTimeout(resolve, 700));
+
+  console.log('Driver setup completed!');
+  await uc.driverSetupComplete(wsHandle);
+});
+
 // create a light entity
 // normally you'd create this where your driver exposed the available entities
 // The entity name can either be string (which will be mapped to english), or a Map with multiple language entries.

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const uc = require('uc-integration-api');
+// use package in production
+// const uc = require("uc-integration-api");
+const uc = require('../index');
 uc.init('driver.json');
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/examples/simulated-light/light-driver.json
+++ b/examples/simulated-light/light-driver.json
@@ -1,0 +1,48 @@
+{
+	"driver_id": "uc_node_driver",
+	"version": "1.0.0",
+	"min_core_api": "1.0.0",
+	"name": { "fr": "Mon driveur", "en": "My Driver", "de": "Mein Treiber", "de-CH": "Min Triber"},
+	"icon": "custom:my_driver_icon",
+	"description": { "en": "A simple demo integration with a simulated light entity." },
+	"#driver_url": "OPTIONAL: the remote uses the driver URL from mDNS if `driver_url` is missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
+	"port": "9988",
+	"developer": {
+		"name": "John Doe",
+		"email": "john@doe.com",
+		"url": "https://www.unfoldedcircle.com"
+	},
+	"home_page": "https://www.unfoldedcircle.com",
+	"setup_data_schema": {
+		"title": {
+			"en": "Simulated integration setup"
+		},
+		"settings": [
+			{
+				"id": "info",
+				"label": {
+					"en": "Demo driver settings page"
+				},
+				"field": {
+					"label": {
+						"value": {
+							"en": "This is some [Markdown](https://en.wikipedia.org/wiki/Markdown) text just for testing.\n\n## Header\n\nMore formatted text, e.g. in _italic_ or **bold**\n\n### Sub header\n\nThe quick brown fox jumps over the lazy dog."
+						}
+					}
+				}
+			},
+			{
+				"id": "confirm",
+				"label": {
+					"en": "I agree"
+				},
+				"field": {
+					"checkbox": {
+						"value": true
+					}
+				}
+			}
+		]
+	},
+	"release_date": "2023-03-03"
+}

--- a/examples/simulated-light/light.js
+++ b/examples/simulated-light/light.js
@@ -2,8 +2,8 @@
 
 // use package in production
 // const uc = require("uc-integration-api");
-const uc = require('../index');
-uc.init('driver.json');
+const uc = require('../../index');
+uc.init('light-driver.json');
 
 uc.on(uc.EVENTS.CONNECT, async () => {
   await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
@@ -53,17 +53,19 @@ uc.on(uc.EVENTS.SETUP_DRIVER, async (wsHandle, setupData) => {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   console.log('Requesting user confirmation to finish setup...');
-  await uc.requestDriverSetupUserConfirmation(wsHandle, 'Please confirm driver setup');
+  await uc.requestDriverSetupUserConfirmation(wsHandle, 'Please click next to continue driver setup');
 });
 
 uc.on(uc.EVENTS.SETUP_DRIVER_USER_DATA, async (wsHandle, userData) => {
-  console.log(`Received user input for driver setup: ${userData}`);
+  console.log('Received user input for driver setup');
+  await uc.acknowledgeCommand(wsHandle);
 
   // implement interactive setup flow, this is just a simulated example
   // ...
+  await new Promise(resolve => setTimeout(resolve, 700));
 
-  // Not expected, send error response
-  await uc.acknowledgeCommand(wsHandle, uc.STATUS_CODES.BAD_REQUEST);
+  console.log('Driver setup completed!');
+  await uc.driverSetupComplete(wsHandle);
 });
 
 uc.on(uc.EVENTS.SETUP_DRIVER_USER_CONFIRMATION, async (wsHandle) => {
@@ -79,8 +81,13 @@ uc.on(uc.EVENTS.SETUP_DRIVER_USER_CONFIRMATION, async (wsHandle) => {
 
   await new Promise(resolve => setTimeout(resolve, 700));
 
-  console.log('Driver setup completed!');
-  await uc.driverSetupComplete(wsHandle);
+  await uc.requestDriverSetupUserInput(wsHandle, 'Data required',
+    [
+      { field: { text: { value: '192.168.100.30' } }, id: 'address', label: { en: 'Hostname or IP address' } },
+      { field: { password: {} }, id: 'token', label: { en: 'Access token' } },
+      { field: { number: { max: 65535, min: 1, value: 1000 } }, id: 'port', label: { en: 'Port' } },
+      { field: { checkbox: { value: false } }, id: 'ssl', label: { en: 'Use SSL' } }
+    ]);
 });
 
 // create a light entity

--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ class IntegrationAPI extends EventEmitter {
       name: this.#driverInfo.driver_id,
       type: 'uc-integration',
       port: this.#driverInfo.port,
-      txt: { name: this.#getDefaultLanguageString(this.#driverInfo.name), ver: this.#driverInfo.version, developer: this.#driverInfo.developer.name }
+      txt: {
+        name: this.#getDefaultLanguageString(this.#driverInfo.name, 'Unknown driver'),
+        ver: this.#driverInfo.version,
+        developer: this.#driverInfo.developer.name
+      }
     });
 
     // TODO #5 handle startup errors if e.g. port is already in use
@@ -137,26 +141,31 @@ class IntegrationAPI extends EventEmitter {
   /**
    * Get the default text from a language text map.
    *
-   * If english `en` is not defined, the first entry is returned.
+   * If english `en` or any `en-##` is not defined, the first entry is returned.
    *
    * @param {object} text The language text map, key is the language identifier, value the language specific text.
+   * @param {string} defaultText The text to return if `text` is empty.
    * @returns {string} The default text.
    */
-  #getDefaultLanguageString (text) {
+  #getDefaultLanguageString (text, defaultText = 'Undefined') {
     if (!text) {
-      return 'Driver without a name';
+      return defaultText;
     }
 
     if (text.en) {
       return text.en;
     }
 
-    // eslint-disable-next-line no-unreachable-loop
-    for (const key in text) {
-      return text[key];
+    for (const [index, [key, value]] of Object.entries(text).entries()) {
+      if (index === 0) {
+        defaultText = value;
+      }
+      if (key.startsWith('en-')) {
+        return text[key];
+      }
     }
 
-    return 'Driver without a name';
+    return defaultText;
   }
 
   #toLanguageObject (text) {

--- a/index.js
+++ b/index.js
@@ -543,6 +543,27 @@ class IntegrationAPI extends EventEmitter {
   }
 
   /**
+   * Request user input during the driver setup flow.
+   *
+   * @param {Object} wsHandle The WebSocket handle received in the `EVENTS.SETUP_DRIVER` event.
+   * @param {string|Map} title A human-readable title of the request screen. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {Array<object>} settings Array of input field definition objects. See Integration-API specification.
+   */
+  async requestDriverSetupUserInput (wsHandle, title, settings) {
+    const msgData = {
+      event_type: 'SETUP',
+      state: 'WAIT_USER_ACTION',
+      require_user_action: {
+        input: {
+          title: this.#toLanguageObject(title),
+          settings
+        }
+      }
+    };
+    await this.#sendEvent(wsHandle.wsId, uc.MSG_EVENTS.DRIVER_SETUP_CHANGE, msgData, uc.EVENT_CATEGORY.DEVICE);
+  }
+
+  /**
    * Confirm successful setup flow completion.
    *
    * Further setup flow messages will be ignored by the Remote.

--- a/index.js
+++ b/index.js
@@ -357,7 +357,12 @@ class IntegrationAPI extends EventEmitter {
           this.emit(uc.EVENTS.DISCONNECT);
           break;
 
+        case uc.MSG_EVENTS.ABORT_DRIVER_SETUP:
+          this.emit(uc.EVENTS.SETUP_DRIVER_ABORT);
+          break;
+
         default:
+          log(`[${wsId}] Unhandled event: ${msg}`);
           break;
       }
     }

--- a/lib/api_definitions.js
+++ b/lib/api_definitions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// TODO a proper enum is reason enough to switch to TS...
+
 const DEVICE_STATES = {
   CONNECTED: 'CONNECTED',
   CONNECTING: 'CONNECTING',
@@ -11,14 +13,21 @@ module.exports.DEVICE_STATES = DEVICE_STATES;
 
 const STATUS_CODES = {
   OK: 200,
+  BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   NOT_FOUND: 404,
-  SERVER_ERROR: 500
+  SERVER_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503
 };
 
 module.exports.STATUS_CODES = STATUS_CODES;
 
-const MESSAGES = {
+/**
+ * WebSocket integration API request / response messages.
+ *
+ * @type {Readonly<{GET_ENTITY_STATES: string, SUBSCRIBE_EVENTS: string, GET_DEVICE_STATE: string, AUTHENTICATION: string, GET_AVAILABLE_ENTITIES: string, GET_DRIVER_VERSION: string, UNSUBSCRIBE_EVENTS: string, ENTITY_COMMAND: string, SETUP_DRIVER: string, GET_DRIVER_METADATA: string, SET_DRIVER_USER_DATA: string}>}
+ */
+const MESSAGES = Object.freeze({
   AUTHENTICATION: 'authentication',
   GET_DRIVER_VERSION: 'get_driver_version',
   GET_DEVICE_STATE: 'get_device_state',
@@ -27,20 +36,19 @@ const MESSAGES = {
   SUBSCRIBE_EVENTS: 'subscribe_events',
   UNSUBSCRIBE_EVENTS: 'unsubscribe_events',
   ENTITY_COMMAND: 'entity_command',
-  GET_DRIVER_METADATA: 'get_driver_metadata'
-};
+  GET_DRIVER_METADATA: 'get_driver_metadata',
+  SETUP_DRIVER: 'setup_driver',
+  SET_DRIVER_USER_DATA: 'set_driver_user_data'
+});
 
 module.exports.MESSAGES = MESSAGES;
 
-// FIXME split into events and responses
-const EVENTS = {
-  // own events
-  ENTITY_COMMAND: 'entity_command',
-  ENTITY_ATTRIBUTES_UPDATED: 'entity_attributes_updated',
-  SUBSCRIBE_ENTITIES: 'subscribe_entities',
-  UNSUBSCRIBE_ENTITIES: 'unsubscribe_entities',
-
-  // integration api events
+/**
+ * WebSocket integration API event messages.
+ *
+ * @type {Readonly<{DRIVER_VERSION: string, ENTITY_STATES: string, DRIVER_METADATA: string, ENTITY_CHANGE: string, DRIVER_SETUP_CHANGE: string, AVAILABLE_ENTITIES: string, CONNECT: string, DISCONNECT: string, DEVICE_STATE: string}>}
+ */
+const MSG_EVENTS = Object.freeze({
   CONNECT: 'connect',
   DISCONNECT: 'disconnect',
   DRIVER_VERSION: 'driver_version',
@@ -48,14 +56,34 @@ const EVENTS = {
   AVAILABLE_ENTITIES: 'available_entities',
   ENTITY_STATES: 'entity_states',
   ENTITY_CHANGE: 'entity_change',
-  DRIVER_METADATA: 'driver_metadata'
-};
+  DRIVER_METADATA: 'driver_metadata',
+  DRIVER_SETUP_CHANGE: 'driver_setup_change'
+});
+
+module.exports.MSG_EVENTS = MSG_EVENTS;
+
+/**
+ * Library events.
+ *
+ * @type {Readonly<{ENTITY_ATTRIBUTES_UPDATED: symbol, ENTITY_COMMAND: symbol, SETUP_DRIVER: symbol, SUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_DATA: symbol, CONNECT: symbol, UNSUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_CONFIRMATION: symbol, DISCONNECT: symbol}>}
+ */
+const EVENTS = Object.freeze({
+  ENTITY_COMMAND: Symbol('entity_command'),
+  ENTITY_ATTRIBUTES_UPDATED: Symbol('entity_attributes_updated'),
+  SUBSCRIBE_ENTITIES: Symbol('subscribe_entities'),
+  UNSUBSCRIBE_ENTITIES: Symbol('unsubscribe_entities'),
+  SETUP_DRIVER: Symbol('setup_driver'),
+  SETUP_DRIVER_USER_DATA: Symbol('setup_driver_user_data'),
+  SETUP_DRIVER_USER_CONFIRMATION: Symbol('setup_driver_user_confirmation'),
+  CONNECT: Symbol('connect'),
+  DISCONNECT: Symbol('disconnect')
+});
 
 module.exports.EVENTS = EVENTS;
 
-const EVENT_CATEGORY = {
+const EVENT_CATEGORY = Object.freeze({
   DEVICE: 'DEVICE',
   ENTITY: 'ENTITY'
-};
+});
 
 module.exports.EVENT_CATEGORY = EVENT_CATEGORY;

--- a/lib/api_definitions.js
+++ b/lib/api_definitions.js
@@ -46,7 +46,7 @@ module.exports.MESSAGES = MESSAGES;
 /**
  * WebSocket integration API event messages.
  *
- * @type {Readonly<{DRIVER_VERSION: string, ENTITY_STATES: string, DRIVER_METADATA: string, ENTITY_CHANGE: string, DRIVER_SETUP_CHANGE: string, AVAILABLE_ENTITIES: string, CONNECT: string, DISCONNECT: string, DEVICE_STATE: string}>}
+ * @type {Readonly<{ABORT_DRIVER_SETUP: string, DRIVER_VERSION: string, ENTITY_STATES: string, DRIVER_METADATA: string, ENTITY_CHANGE: string, DRIVER_SETUP_CHANGE: string, AVAILABLE_ENTITIES: string, CONNECT: string, DISCONNECT: string, DEVICE_STATE: string}>}
  */
 const MSG_EVENTS = Object.freeze({
   CONNECT: 'connect',
@@ -57,7 +57,8 @@ const MSG_EVENTS = Object.freeze({
   ENTITY_STATES: 'entity_states',
   ENTITY_CHANGE: 'entity_change',
   DRIVER_METADATA: 'driver_metadata',
-  DRIVER_SETUP_CHANGE: 'driver_setup_change'
+  DRIVER_SETUP_CHANGE: 'driver_setup_change',
+  ABORT_DRIVER_SETUP: 'abort_driver_setup'
 });
 
 module.exports.MSG_EVENTS = MSG_EVENTS;
@@ -65,7 +66,7 @@ module.exports.MSG_EVENTS = MSG_EVENTS;
 /**
  * Library events.
  *
- * @type {Readonly<{ENTITY_ATTRIBUTES_UPDATED: symbol, ENTITY_COMMAND: symbol, SETUP_DRIVER: symbol, SUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_DATA: symbol, CONNECT: symbol, UNSUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_CONFIRMATION: symbol, DISCONNECT: symbol}>}
+ * @type {Readonly<{SETUP_DRIVER_ABORT: symbol, ENTITY_ATTRIBUTES_UPDATED: symbol, ENTITY_COMMAND: symbol, SETUP_DRIVER: symbol, SUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_DATA: symbol, CONNECT: symbol, UNSUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_CONFIRMATION: symbol, DISCONNECT: symbol}>}
  */
 const EVENTS = Object.freeze({
   ENTITY_COMMAND: Symbol('entity_command'),
@@ -75,6 +76,7 @@ const EVENTS = Object.freeze({
   SETUP_DRIVER: Symbol('setup_driver'),
   SETUP_DRIVER_USER_DATA: Symbol('setup_driver_user_data'),
   SETUP_DRIVER_USER_CONFIRMATION: Symbol('setup_driver_user_confirmation'),
+  SETUP_DRIVER_ABORT: Symbol('setup_driver_abort'),
   CONNECT: Symbol('connect'),
   DISCONNECT: Symbol('disconnect')
 });

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -11,6 +11,7 @@ const Light = require('./light');
 const MediaPlayer = require('./media_player');
 const Sensor = require('./sensor');
 const Switch = require('./switch');
+const { EVENTS } = require('../api_definitions');
 
 class Entities extends EventEmitter {
   #storage;
@@ -104,7 +105,7 @@ class Entities extends EventEmitter {
     attributes.forEach((value, key) => { this.#storage[id].attributes[key] = value; });
 
     this.emit(
-      'entity_attributes_updated',
+      EVENTS.ENTITY_ATTRIBUTES_UPDATED,
       id,
       this.#storage[id].entity_type,
       attributes


### PR DESCRIPTION
core-api & core-simulator are soon ready with the integration setup flow. 
This PR shows the new features

- added support for new messages: `setup_driver`, `set_driver_user_data`, `driver_setup_change`, `abort_driver_setup`
- refactored examples: one subdirectory per example
- enhanced example README
- minimal example is now runnable and can be registered in the simulator with the web-configurator
- refactor message & event "enums"
  - separate internal events from API event messages
  - use symbols for internal events for a clear separation and to disallow untyped strings