### PR TITLE
fix: advertise hostname in .local domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,8 +98,14 @@ class IntegrationAPI extends EventEmitter {
 
       log("Starting mdns advertising");
 
+      // Make sure to advertise a .local hostname. It seems that bonjour just blindly takes the hostname, short or FQDN.
+      // The remote only supports multicast DNS resolution in the .local domain.
+      // Test with: avahi-browse -d local _uc-integration._tcp --resolve -t
+      const hostname = os.hostname().split(".")[0] + ".local.";
+
       bonjour.publish({
         name: this.#driverInfo.driver_id,
+        host: hostname,
         type: "uc-integration",
         port: integrationPort || this.#driverInfo.port,
         txt: {


### PR DESCRIPTION
Quick fix to make sure the hostname is in the .local domain, otherwise it can't be resolved on the remote with multicast DNS resolution.

Closes #19