### PR TITLE
refactor!: remove available & configured entity persistence.

### DIFF
--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -29,18 +29,18 @@ uc.on(uc.EVENTS.EXIT_STANDBY, async () => {
 });
 
 uc.on(uc.EVENTS.SUBSCRIBE_ENTITIES, async (entityIds) => {
-  // the integration will configure entities and subscribe for entity update events
-  // the UC library automatically adds the subscribed entities
-  // from available to configured
-  // you can act on this event if you need for your device handling
+  // The integration will configure entities and subscribe for entity update events.
+  // The UC library automatically adds the subscribed entities
+  // from the available to the configured pool.
+  // You can act on this event if you need for your device handling.
   // ...
 });
 
 uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entityIds) => {
-  // when the integration unsubscribed from certain entity updates,
-  // the UC library automatically remove the unsubscribed entities
-  // from configured
-  // you can act on this event if you need for your device handling
+  // When the integration unsubscribed from certain entity updates,
+  // the UC library automatically removes the unsubscribed entities
+  // from the configured pool.
+  // You can act on this event if you need for your device handling.
   // ...
 });
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class IntegrationAPI extends EventEmitter {
 
   /**
    * Initialize the library
-   * @param {string|object} either a string to specify the driver configuration file path, or an object holding the configuration
+   * @param {string|object} driverConfig either a string to specify the driver configuration file path, or an object holding the configuration
    */
   init(driverConfig) {
     const integrationInterface = process.env.UC_INTEGRATION_INTERFACE;
@@ -477,8 +477,6 @@ class IntegrationAPI extends EventEmitter {
       }
     });
 
-    this.configuredEntities.saveData();
-
     this.emit(uc.EVENTS.SUBSCRIBE_ENTITIES, entities.entity_ids);
   }
 
@@ -491,8 +489,6 @@ class IntegrationAPI extends EventEmitter {
         res = false;
       }
     });
-
-    this.configuredEntities.saveData();
 
     this.emit(uc.EVENTS.UNSUBSCRIBE_ENTITIES, entities.entity_ids);
 

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const EventEmitter = require("events");
-const fs = require("fs");
 
 const Entity = require("./entity");
 const Button = require("./button");
@@ -15,28 +14,12 @@ const { EVENTS } = require("../api_definitions");
 
 class Entities extends EventEmitter {
   #storage;
-  #dataPath;
 
   constructor(id) {
     super();
 
     this.id = id;
     this.#storage = {};
-    this.#dataPath = `${this.id}.json`;
-
-    // load configured entities
-    if (fs.existsSync(this.#dataPath)) {
-      const raw = fs.readFileSync(this.#dataPath);
-
-      try {
-        this.#storage = JSON.parse(raw);
-        console.log(`ENTITIES(${this.id}): config file loaded.`);
-      } catch (e) {
-        console.log(`ENTITIES(${this.id}): Error parsing entities: ${this.#dataPath}`);
-      }
-    } else {
-      console.log(`ENTITIES(${this.id}): No storage file, will create one later: ${this.#dataPath}`);
-    }
   }
 
   static generateId(prefix = "entity") {
@@ -146,16 +129,6 @@ class Entities extends EventEmitter {
 
   clear() {
     this.#storage = {};
-    this.saveData();
-  }
-
-  saveData() {
-    try {
-      fs.writeFileSync(this.#dataPath, JSON.stringify(this.#storage));
-      console.log(`ENTITIES(${this.id}): Config saved to file: ${this.#dataPath}`);
-    } catch (e) {
-      console.error(`ENTITIES(${this.id}): Error writing config: ${this.#dataPath}`);
-    }
   }
 }
 


### PR DESCRIPTION
The storage pools for available and configured entities are no longer persisted. Storing the available pool was not working, and storing the configured pool only creates more issues.
An integration driver knows best how to create and maintain its entities. A real world use-case is that entities disappear and never come back. With storing the previously configured entities, this can get out of sync fast.

BREAKING CHANGE: entity attributes from the last run are no longer persisted. For example the entity state or album art for a media-player entity.
The integration driver is now fully responsible to persist required data between driver restarts. Furthermore, all available entities have to be added to the available pool during startup.