### PR TITLE
Setup handler & entity command handler instead of events

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,26 @@
+name: Run unit tests
+
+on:
+  push:
+    paths:
+      - '**/*.js'
+      - '.github/**/*.yml'
+      - 'package-lock.json'
+  pull_request:
+    # feature branch for testing only before PR
+    branches: [ "main", "refactor/setup-flow" ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  eslint:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run configured tests
+        run: npm run test

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Not supported:
 - Token based authentication
 
 Requirements:
-- Node.js v16 or newer (older versions are not tested)
+- Node.js v16.18.0 or newer (older versions are not tested)
 
 ## Installation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ integration driver.
 
 ## simulated-light
 
-Simple one light integration example with a driver setup flow.
+Simple one light integration example with a push-button to toggle the light.
 
 This example creates one simulated light entity and handles basic commands sent from the `remote-core`.
 
@@ -20,6 +20,22 @@ cd simulated-light
 npm install
 node light.js
 ```
+
+## setup-flow
+
+The [setup_flow](setup-flow/setup_flow.js) example shows how to define a dynamic setup flow for the driver setup.
+
+If the user selects the _expert_ option in the main setup screen:
+
+1. An input screen is shown asking to select an item from a dropdown list.
+2. The chosen option will be shown in the next input screen with another setting, on how many button entities to create.
+3. The number of push buttons are created.
+
+The available input settings are defined in the [Integration-API asyncapi.yaml definition](https://github.com/unfoldedcircle/core-api/tree/main/integration-api)
+and are not yet available as classes.
+
+See `Setting` object definition and the referenced SettingTypeNumber, SettingTypeText, SettingTypeTextArea,
+SettingTypePassword, SettingTypeCheckbox, SettingTypeDropdown, SettingTypeLabel.
 
 ## Driver configuration
 
@@ -42,10 +58,10 @@ Edit `driver.json` if you'd like to change the port or any other information.
   - While configuring an integration driver, the user can also override the driver address.
 - The `setup_data_schema` property enables the driver setup flow to configure the driver during registration.
   - The first request sent is `setup_driver` containing the provided input values (if there are input fields).  
-    This triggers the `uc.EVENTS.SETUP_DRIVER` event in the library which the integration driver has to acknowledge.
-  - From there on, the integration driver needs to send `driver_setup_change` messages with the setup status, or user
-    input requests. This is handled with calling `uc.driverSetupProgress` and `uc.requestDriverSetupUserConfirmation`.
-  - See [simulated-light/light.js](simulated-light/light.js) for an example and the [Integration-API documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/integration-driver).
+    This triggers the (optional) setup handler callback provided in the `init` call.
+  - From there on, the integration driver needs to handle the `SetupDriver` instances and return an appropriate action.
+  - See [setup-flow/setup_flow.js](setup-flow/setup_flow.js) for an example and the [Integration-API documentation](https://github.com/unfoldedcircle/core-api/tree/main/doc/integration-driver).
+  - ⚠️ the `uc.EVENTS.SETUP_DRIVER` event is deprecated and will be removed at the end of 2024!
 
 ## Driver registration
 

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -44,9 +44,20 @@ uc.on(uc.EVENTS.UNSUBSCRIBE_ENTITIES, async (entityIds) => {
   // ...
 });
 
-// handle commands coming from the core
-uc.on(uc.EVENTS.ENTITY_COMMAND, async (wsHandle, entityId, entityType, cmdId, params) => {
-  console.log(`ENTITY COMMAND: ${entityId} ${entityType} ${cmdId} ${JSON.stringify(params, null, 4)}`);
+// handle commands coming from the core, either with a shared command handler for all entities, or individual handlers
+// per entity or entity type
+/**
+ * Entity command handler.
+ *
+ * Called by the integration-API if a command is sent to a configured entity.
+ *
+ * @param {uc.Entities.Entity} entity button entity
+ * @param {string} cmdId command
+ * @param {Object<string, *>} params optional command parameters
+ * @return {Promise<string>} status of the command
+ */
+async function cmdHandler(entity, cmdId, params) {
+  console.log("Got %s command request: %s", entity.id, cmdId, params || "");
 
   // handle entity commands here
   // execute commands on your integration devices
@@ -55,11 +66,10 @@ uc.on(uc.EVENTS.ENTITY_COMMAND, async (wsHandle, entityId, entityType, cmdId, pa
 
   // ...
 
-  // you need to acknowledge if the command was successfully executed
-  // default is uc.STATUS_CODES.OK
-  const statusCode = uc.STATUS_CODES.NOT_FOUND;
-  await uc.acknowledgeCommand(wsHandle, statusCode);
-});
+  // you need to acknowledge if the command was successfully executed with STATUS_CODES.OK
+  // or an error code
+  return uc.STATUS_CODES.NOT_IMPLEMENTED;
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // Providing Available entities
@@ -84,6 +94,7 @@ const entity = new uc.Entities.MediaPlayer(
     [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME, 0]
   ])
 );
+entity.setCmdHandler(cmdHandler);
 
 // 2. add available entity to the core
 uc.availableEntities.addEntity(entity);

--- a/examples/setup-flow/setup_flow.js
+++ b/examples/setup-flow/setup_flow.js
@@ -1,0 +1,168 @@
+/**
+ * Integration setup flow example.
+ */
+"use strict";
+
+// use package in production
+// const uc = require("uc-integration-api");
+const uc = require("../../index");
+
+/**
+ * Dispatch driver setup requests to corresponding handlers.
+ *
+ * Either start the setup process or handle the provided user input data.
+ * @param {uc.setup.SetupDriver} msg the setup driver request object, either DriverSetupRequest,
+ *                 UserDataResponse or UserConfirmationResponse
+ * @return {Promise<uc.setup.SetupAction>} the setup action on how to continue
+ */
+async function driverSetupHandler(msg) {
+  if (msg instanceof uc.setup.DriverSetupRequest) {
+    return await handleDriverSetup(msg);
+  }
+  if (msg instanceof uc.setup.UserDataResponse) {
+    return await handleUserDataResponse(msg);
+  }
+
+  // user confirmation not used in our demo setup process
+  // if (msg instanceof UserConfirmationResponse) {
+  //     return handle_user_confirmation(msg)
+  // }
+
+  return new uc.setup.SetupError();
+}
+
+/**
+ * Start driver setup.
+ *
+ * Initiated by the UC Remote to set up the driver.
+ * @param {uc.setup.DriverSetupRequest} msg value(s) of input fields in the first setup screen.
+ * @return {Promise<uc.setup.SetupAction>} the setup action on how to continue
+ */
+async function handleDriverSetup(msg) {
+  // No support for reconfiguration :-)
+  if (msg.reconfigure) {
+    console.log("Ignoring driver reconfiguration request");
+  }
+
+  // For our demo we simply clear everything!
+  // A real driver might have to handle this differently
+  uc.availableEntities.clear();
+  uc.configuredEntities.clear();
+
+  // check if user selected the expert option in the initial setup screen
+  // please note that all values are returned as strings!
+  if (!("expert" in msg.setupData) || msg.setupData.expert !== "true") {
+    // add a single button as default action
+    const button = new uc.Entities.Button("button", "Button", "test lab", cmdHandler);
+    uc.availableEntities.addEntity(button);
+    return new uc.setup.SetupComplete();
+  }
+
+  // Dropdown selections are usually set dynamically, e.g. with found devices etc.
+  const dropdownItems = [
+    { id: "red", label: { en: "Red", de: "Rot" } },
+    { id: "green", label: { en: "Green", de: "Grün" } },
+    { id: "blue", label: { en: "Blue", de: "Blau" } }
+  ];
+
+  return new uc.setup.RequestUserInput({ en: "Please choose", de: "Bitte auswählen" }, [
+    {
+      id: "info",
+      label: { en: "Setup flow example", de: "Setup Flow Beispiel" },
+      field: {
+        label: {
+          value: {
+            en:
+              "This is just some informational text.\n" +
+              "Simple **Markdown** is supported!\n" +
+              "For example _some italic text_.\n" +
+              "#// Or a header text\n~~strikethrough txt~~"
+          }
+        }
+      }
+    },
+    {
+      field: { dropdown: { value: "", items: dropdownItems } },
+      id: "step1.choice",
+      label: {
+        en: "Choose color",
+        de: "Wähle Farbe"
+      }
+    }
+  ]);
+}
+
+/**
+ * Process user data response in a setup process.
+ *
+ * Driver setup callback to provide requested user data during the setup process.
+ * @param {uc.setup.UserDataResponse} msg response data from the requested user data
+ * @return {Promise<uc.setup.SetupAction>} the setup action on how to continue: SetupComplete if finished.
+ */
+async function handleUserDataResponse(msg) {
+  // values from all screens are returned: check in reverse order
+  if ("step2.count" in msg.inputValues) {
+    for (let x = 0; x < parseInt(msg.inputValues["step2.count"]); x++) {
+      const button = new uc.Entities.Button(`button${x}`, `Button ${x + 1}`);
+      button.setCmdHandler(cmdHandler);
+      uc.availableEntities.addEntity(button);
+    }
+
+    return new uc.setup.SetupComplete();
+  }
+
+  if ("step1.choice" in msg.inputValues) {
+    const choice = msg.inputValues["step1.choice"];
+    console.log("Chosen color:", choice);
+    return new uc.setup.RequestUserInput({ en: "Step 2" }, [
+      {
+        id: "info",
+        label: {
+          en: "Selected value from previous step:",
+          de: "Selektierter Wert vom vorherigen Schritt:"
+        },
+        field: {
+          label: {
+            value: {
+              en: choice
+            }
+          }
+        }
+      },
+      {
+        field: { number: { value: 1, min: 1, max: 100, steps: 2 } },
+        id: "step2.count",
+        label: {
+          en: "Button instance count",
+          de: "Anzahl Button Instanzen"
+        }
+      }
+    ]);
+  }
+
+  console.log("No choice was received");
+  return new uc.setup.SetupError();
+}
+
+/**
+ * Push button command handler.
+ *
+ * Called by the integration-API if a command is sent to a configured button-entity.
+ *
+ * @param {uc.Entities.Entity} entity button entity
+ * @param {string} cmdId command
+ * @param {Object<string, *>} _params optional command parameters (not used for buttons)
+ * @return {Promise<string>} status of the command
+ */
+async function cmdHandler(entity, cmdId, _params) {
+  console.log("Got %s command request: %s", entity.id, cmdId);
+
+  return uc.STATUS_CODES.OK;
+}
+
+uc.on(uc.EVENTS.CONNECT, async () => {
+  // When the remote connects, we just set the device state. We are ready all the time!
+  await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
+});
+
+uc.init("setup_flow.json", driverSetupHandler);

--- a/examples/setup-flow/setup_flow.json
+++ b/examples/setup-flow/setup_flow.json
@@ -1,0 +1,40 @@
+{
+  "driver_id": "setupflow_example",
+  "version": "0.0.1",
+  "min_core_api": "0.20.0",
+  "name": { "en": "Setup Flow Node.js Demo" },
+  "icon": "uc:integration",
+  "description": {
+    "en": "Setup Flow Python integration driver example."
+  },
+  "port": 9081,
+  "developer": {
+    "name": "Unfolded Circle ApS",
+    "email": "hello@unfoldedcircle.com",
+    "url": "https://www.unfoldedcircle.com"
+  },
+  "home_page": "https://www.unfoldedcircle.com",
+  "setup_data_schema": {
+    "title": {
+      "en": "Example settings",
+      "de": "Beispiel Konfiguration",
+      "fr": "Exemple de configuration"
+    },
+    "settings": [
+      {
+        "id": "expert",
+        "label": {
+          "en": "Configure enhanced options",
+          "de": "Erweiterte Optionen konfigurieren",
+          "fr": "Configurer les options avancées"
+        },
+        "field": {
+          "checkbox": {
+            "value": false
+          }
+        }
+      }
+    ]
+  },
+  "release_date": "2023-11-03"
+}

--- a/examples/simulated-light/light-driver.json
+++ b/examples/simulated-light/light-driver.json
@@ -13,36 +13,5 @@
     "url": "https://www.unfoldedcircle.com"
   },
   "home_page": "https://www.unfoldedcircle.com",
-  "setup_data_schema": {
-    "title": {
-      "en": "Simulated integration setup"
-    },
-    "settings": [
-      {
-        "id": "info",
-        "label": {
-          "en": "Demo driver settings page"
-        },
-        "field": {
-          "label": {
-            "value": {
-              "en": "This is some [Markdown](https://en.wikipedia.org/wiki/Markdown) text just for testing.\n\n## Header\n\nMore formatted text, e.g. in _italic_ or **bold**\n\n### Sub header\n\nThe quick brown fox jumps over the lazy dog."
-            }
-          }
-        }
-      },
-      {
-        "id": "confirm",
-        "label": {
-          "en": "I agree"
-        },
-        "field": {
-          "checkbox": {
-            "value": true
-          }
-        }
-      }
-    ]
-  },
   "release_date": "2023-03-03"
 }

--- a/lib/api_definitions.js
+++ b/lib/api_definitions.js
@@ -22,7 +22,10 @@ const STATUS_CODES = {
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   NOT_FOUND: 404,
+  TIMEOUT: 408,
+  CONFLICT: 409,
   SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
   SERVICE_UNAVAILABLE: 503
 };
 
@@ -74,16 +77,36 @@ module.exports.MSG_EVENTS = MSG_EVENTS;
 /**
  * Library events.
  *
+ * ⚠️ The following events are deprecated and will be removed at the end of 2024:
+ * - `ENTITY_COMMAND`: use entity command callback handler instead.
+ * - `SETUP_DRIVER, SETUP_DRIVER_USER_DATA, SETUP_DRIVER_USER_CONFIRMATION, SETUP_DRIVER_ABORT`:
+ *    use setup callback handler instead. See init method.
+ *
  * @type {Readonly<{SETUP_DRIVER_ABORT: symbol, ENTITY_ATTRIBUTES_UPDATED: symbol, ENTITY_COMMAND: symbol, SETUP_DRIVER: symbol, SUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_DATA: symbol, CONNECT: symbol, UNSUBSCRIBE_ENTITIES: symbol, SETUP_DRIVER_USER_CONFIRMATION: symbol, DISCONNECT: symbol,  ENTER_STANDBY: symbol,  EXIT_STANDBY: symbol}>}
  */
 const EVENTS = Object.freeze({
+  /**
+   * @deprecated use entity command callback handler instead.
+   */
   ENTITY_COMMAND: Symbol("entity_command"),
   ENTITY_ATTRIBUTES_UPDATED: Symbol("entity_attributes_updated"),
   SUBSCRIBE_ENTITIES: Symbol("subscribe_entities"),
   UNSUBSCRIBE_ENTITIES: Symbol("unsubscribe_entities"),
+  /**
+   * @deprecated use setup callback handler instead. See init method.
+   */
   SETUP_DRIVER: Symbol("setup_driver"),
+  /**
+   * @deprecated use setup callback handler instead. See init method.
+   */
   SETUP_DRIVER_USER_DATA: Symbol("setup_driver_user_data"),
+  /**
+   * @deprecated use setup callback handler instead. See init method.
+   */
   SETUP_DRIVER_USER_CONFIRMATION: Symbol("setup_driver_user_confirmation"),
+  /**
+   * @deprecated use setup callback handler instead. See init method.
+   */
   SETUP_DRIVER_ABORT: Symbol("setup_driver_abort"),
   CONNECT: Symbol("connect"),
   DISCONNECT: Symbol("disconnect"),
@@ -99,3 +122,174 @@ const EVENT_CATEGORY = Object.freeze({
 });
 
 module.exports.EVENT_CATEGORY = EVENT_CATEGORY;
+
+/**
+ * More detailed error reason for `state: ERROR` condition.
+ */
+class IntegrationSetupError {
+  static NONE = "NONE";
+  static NOT_FOUND = "NOT_FOUND";
+  static CONNECTION_REFUSED = "CONNECTION_REFUSED";
+  static AUTHORIZATION_ERROR = "AUTHORIZATION_ERROR";
+  static TIMEOUT = "TIMEOUT";
+  static OTHER = "OTHER";
+}
+
+/**
+ * Driver setup request base class.
+ */
+class SetupDriver {
+  // Base class for setup requests
+}
+
+/**
+ * Start driver setup.
+ *
+ * If a driver includes a `setup_data_schema` object in its driver metadata, it enables the dynamic
+ * driver setup process.
+ *
+ * The `reconfigure` flag indicates if the user wants to reconfigure an already configured driver in the Remote.
+ * It's up to the driver on how to handle a reconfiguration request and run a different logic. For example, this
+ * allows to show an options screen to change certain values, or present the option to modify, add or delete
+ * provided device entities.
+ *
+ * The `setupData` parameter holds the user input result of a SettingsPage as key values.
+ * - key: id of the field
+ * - value: entered user value as string. This is either the entered text or number, selected checkbox state or the
+ *          selected dropdown item id.
+ *
+ * ⚠️ Non-native string values as numbers or booleans are represented as string values!
+ *
+ * The integration driver has to respond with one of the following action objects:
+ * - `RequestUserInput`: request a user input
+ * - `RequestUserConfirmation`: request a user confirmation
+ * - `SetupComplete` finishes the setup process and the UC Remote creates an integration instance.
+ * - `SetupError` aborts the setup process.
+ */
+class DriverSetupRequest extends SetupDriver {
+  /**
+   * @param {boolean} reconfigure If set to `true`: reconfigure an already configured driver.
+   * @param {Object.<string, string>} setupData User input result of a SettingsPage as key values.
+   */
+  constructor(reconfigure, setupData) {
+    super();
+    this.reconfigure = reconfigure;
+    this.setupData = setupData;
+  }
+}
+
+/**
+ * Provide requested driver setup data to the integration driver in a setup process.
+ */
+class UserDataResponse extends SetupDriver {
+  /**
+   * @param {Object.<string, string>} inputValues User input result of a SettingsPage as key values.
+   */
+  constructor(inputValues) {
+    super();
+    this.inputValues = inputValues;
+  }
+}
+
+/**
+ * Provide user confirmation response to the integration driver in a setup process.
+ */
+class UserConfirmationResponse extends SetupDriver {
+  /**
+   * @param {boolean} confirm User confirmation
+   */
+  constructor(confirm) {
+    super();
+    this.confirm = confirm;
+  }
+}
+
+/**
+ * Abort notification.
+ */
+class AbortDriverSetup extends SetupDriver {
+  /**
+   * @param {string} error one of the defined errors in {@link IntegrationSetupError}
+   */
+  constructor(error) {
+    super();
+    this.error = error;
+  }
+}
+
+/**
+ * Setup action response base class.
+ */
+class SetupAction {
+  // Base class for setup actions
+}
+
+/**
+ * Setup action to request user input.
+ */
+class RequestUserInput extends SetupAction {
+  /**
+   * @param {string | Map<string, string>|Object.<string, string>} title Confirmation page title of the request screen.
+   * @param {Array.<Object.<string, any>>} settings Settings page definition. See Integration-API for all options.
+   */
+  constructor(title, settings) {
+    super();
+    this.title = title;
+    this.settings = settings;
+  }
+}
+
+/**
+ * Setup action to request a user confirmation.
+ */
+class RequestUserConfirmation extends SetupAction {
+  /**
+   * Create a new user confirmation request.
+   * All text strings are either a simple string, which will be mapped to English, or a Map / Object containing multiple language strings.
+   * @param {string | Map<string, string>|Object.<string, string>} title Confirmation page title of the request screen.
+   * @param {string | Map<string, string>|Object.<string, string> | null} header Optional header text.
+   * @param {string | null} image Optional base64 encoded image which will be shown between the header and footer texts.
+   * @param {string | Map<string, string>|Object.<string, string> | null} footer Optional footer text.
+   */
+  constructor(title, header = null, image = null, footer = null) {
+    super();
+    this.title = title;
+    this.header = header;
+    this.image = image;
+    this.footer = footer;
+  }
+}
+
+/**
+ * Setup action to abort setup process due to an error.
+ */
+class SetupError extends SetupAction {
+  /**
+   * @param {string} [errorType=IntegrationSetupError.OTHER] one of the defined errors in {@link IntegrationSetupError}
+   */
+  constructor(errorType = IntegrationSetupError.OTHER) {
+    super();
+    this.errorType = errorType;
+  }
+}
+
+/**
+ * Setup action to complete a successful setup process.
+ */
+class SetupComplete extends SetupAction {
+  // Marks setup as complete
+}
+
+module.exports.setup = {
+  IntegrationSetupError,
+  SetupDriver,
+  DriverSetupRequest,
+  UserDataResponse,
+  UserConfirmationResponse,
+  AbortDriverSetup,
+  SetupAction,
+  RequestUserInput,
+  RequestUserConfirmation,
+  SetupError,
+  SetupComplete
+};

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -48,8 +48,9 @@ class Button extends Entity {
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
    * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.   * @param id
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, area = undefined) {
+  constructor(id, name, area = undefined, cmdHandler = undefined) {
     super(
       id,
       name,
@@ -58,7 +59,8 @@ class Button extends Entity {
       new Map([[ATTRIBUTES.STATE, STATES.AVAILABLE]]),
       undefined,
       null,
-      area
+      area,
+      cmdHandler
     );
 
     console.debug(`Button entity created with id: ${this.id}`);

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -103,9 +103,19 @@ class Climate extends Entity {
    * @param {string} deviceClass Optional device class.
    * @param {object} options Further options. See entity documentation.
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, features, attributes, deviceClass = undefined, options = null, area = undefined) {
-    super(id, name, Entity.TYPES.CLIMATE, features, attributes, deviceClass, options, area);
+  constructor(
+    id,
+    name,
+    features,
+    attributes,
+    deviceClass = undefined,
+    options = null,
+    area = undefined,
+    cmdHandler = undefined
+  ) {
+    super(id, name, Entity.TYPES.CLIMATE, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Climate entity created with id: ${this.id}`);
   }

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -102,9 +102,19 @@ class Cover extends Entity {
    * @param {string} deviceClass Optional device class.
    * @param {object} options Further options. See entity documentation.
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, features, attributes, deviceClass = undefined, options = null, area = undefined) {
-    super(id, name, Entity.TYPES.COVER, features, attributes, deviceClass, options, area);
+  constructor(
+    id,
+    name,
+    features,
+    attributes,
+    deviceClass = undefined,
+    options = null,
+    area = undefined,
+    cmdHandler = undefined
+  ) {
+    super(id, name, Entity.TYPES.COVER, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Cover entity created with id: ${this.id}`);
   }

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -140,6 +140,7 @@ class Entities extends EventEmitter {
 
 module.exports = Entities;
 module.exports.TYPES = Entity.TYPES;
+module.exports.Entity = Entity;
 module.exports.Button = Button;
 module.exports.Climate = Climate;
 module.exports.Cover = Cover;

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -107,7 +107,8 @@ class Entities extends EventEmitter {
         features: value.features,
         name: value.name,
         area: value.area,
-        device_class: value.device_class
+        device_class: value.device_class,
+        options: value.options
       };
 
       entities.push(entity);

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -7,6 +7,10 @@
  */
 "use strict";
 
+const { STATUS_CODES } = require("../api_definitions");
+const { toLanguageObject } = require("../utils");
+const assert = require("node:assert");
+
 /**
  * Available entity types.
  *
@@ -23,6 +27,8 @@ const TYPES = {
 };
 
 class Entity {
+  #cmdHandler;
+
   /**
    * Constructs a new entity.
    *
@@ -30,21 +36,70 @@ class Entity {
    * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
    * @param {string} entityType One of defined [Entity.TYPES]{@link TYPES}.
    * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {Map | null} attributes Optional entity attribute Map holding the current state.
+   * @param {string | undefined} deviceClass Optional device class.
+   * @param {object | null} options Further options. See entity documentation.
+   * @param {string | undefined} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, entityType, features, attributes, deviceClass, options, area) {
+  constructor(id, name, entityType, features, attributes, deviceClass, options, area, cmdHandler = undefined) {
+    assert(typeof id === "string", "Entity parameter id must be a string");
     this.id = id;
-    this.name = typeof name === "string" || name instanceof String ? { en: name } : Object.fromEntries(name);
+    this.name = toLanguageObject(name);
+    assert(typeof entityType === "string", "Entity parameter entityType must be a string");
     this.entity_type = entityType;
     this.device_id = null; // not yet supported
+    assert(features instanceof Array, "Entity parameter features must be an Array");
     this.features = features;
+    assert(attributes === null || attributes instanceof Map, "Entity parameter attributes must be a Map");
     this.attributes = attributes ? Object.fromEntries(attributes) : null;
+    assert(
+      deviceClass === undefined || typeof deviceClass === "string",
+      "Entity parameter deviceClass must be a string"
+    );
     this.device_class = deviceClass;
+    assert(options === null || options instanceof Object, "Entity parameter options must be an Object");
     this.options = options;
+    assert(area === undefined || typeof area === "string", "Entity parameter area must be a string");
     this.area = area;
+    assert(
+      cmdHandler === undefined || typeof cmdHandler === "function",
+      "Entity parameter cmdHandler must be a function"
+    );
+    this.#cmdHandler = cmdHandler;
+  }
+
+  /**
+   * Set callback handler for entity command requests.
+   * @param {function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   */
+  setCmdHandler(cmdHandler) {
+    this.#cmdHandler = cmdHandler;
+  }
+
+  /**
+   * @return {boolean} true if a callback handler for entity commands has been installed.
+   */
+  get hasCmdHandler() {
+    return this.#cmdHandler !== undefined && this.#cmdHandler !== null;
+  }
+
+  /**
+   * Execute entity command with the installed command handler.
+   *
+   * Returns NOT_IMPLEMENTED if no command handler is installed.
+   * @param {string} cmdId the command
+   * @param {Object.<string, *> } params optional command parameters
+   * @return {Promise<string>} command status code to acknowledge to UC Remote
+   */
+  async command(cmdId, params) {
+    if (this.#cmdHandler) {
+      return await this.#cmdHandler(this, cmdId, params);
+    }
+
+    console.warn("No command handler for %s: cannot execute command '%s' %s", this.id, cmdId, params || "");
+
+    return STATUS_CODES.NOT_IMPLEMENTED;
   }
 }
 

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -86,9 +86,19 @@ class Light extends Entity {
    * @param {string} deviceClass Optional device class.
    * @param {object} options Further options. See entity documentation.
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, features, attributes, deviceClass = undefined, options = null, area = undefined) {
-    super(id, name, Entity.TYPES.LIGHT, features, attributes, deviceClass, options, area);
+  constructor(
+    id,
+    name,
+    features,
+    attributes,
+    deviceClass = undefined,
+    options = null,
+    area = undefined,
+    cmdHandler = undefined
+  ) {
+    super(id, name, Entity.TYPES.LIGHT, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Light entity created with id: ${this.id}`);
   }

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -223,9 +223,19 @@ class MediaPlayer extends Entity {
    * @param {string} deviceClass Optional device class.
    * @param {object} options Further options. See entity documentation.
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, features, attributes, deviceClass = undefined, options = null, area = undefined) {
-    super(id, name, Entity.TYPES.MEDIA_PLAYER, features, attributes, deviceClass, options, area);
+  constructor(
+    id,
+    name,
+    features,
+    attributes,
+    deviceClass = undefined,
+    options = null,
+    area = undefined,
+    cmdHandler = undefined
+  ) {
+    super(id, name, Entity.TYPES.MEDIA_PLAYER, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`MediaPlayer entity created with id: ${this.id}`);
   }

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -83,9 +83,19 @@ class Switch extends Entity {
    * @param {string} deviceClass Optional device class.
    * @param {object} options Further options. See entity documentation.
    * @param {string} area Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
    */
-  constructor(id, name, features, attributes, deviceClass = undefined, options = null, area = undefined) {
-    super(id, name, Entity.TYPES.SWITCH, features, attributes, deviceClass, options, area);
+  constructor(
+    id,
+    name,
+    features,
+    attributes,
+    deviceClass = undefined,
+    options = null,
+    area = undefined,
+    cmdHandler = undefined
+  ) {
+    super(id, name, Entity.TYPES.SWITCH, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Switch entity created with id: ${this.id}`);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,65 @@
+/**
+ * Utility functions.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Apache License 2.0, see LICENSE for more details.
+ */
+
+"use strict";
+
+/**
+ * Convert an input text to a language object.
+ *
+ * An input text is either a simple string, which is mapped to the `en` language key, a Map containing language keys and
+ * text values, or an Object with language key fields and text values.s
+ * @param {string | Map<string, string> | Object<string, string> } text
+ * @return {{[p: string]: string}|null}
+ */
+function toLanguageObject(text) {
+  if (text) {
+    if (typeof text === "string" || text instanceof String) {
+      return { en: text };
+    }
+    if (text instanceof Map) {
+      return Object.fromEntries(text);
+    }
+    if (text instanceof Object) {
+      // TODO check if text object only contains string keys & values?
+      return text;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the default text from a language text map.
+ *
+ * If english `en` or any `en-##` is not defined, the first entry is returned.
+ *
+ * @param {Object<string, string>} text The language text map, key is the language identifier, value the language specific text.
+ * @param {string} defaultText The text to return if `text` is empty.
+ * @returns {string} The default text.
+ */
+function getDefaultLanguageString(text, defaultText = "Undefined") {
+  if (!text) {
+    return defaultText;
+  }
+
+  if (text.en) {
+    return text.en;
+  }
+
+  for (const [index, [key, value]] of Object.entries(text).entries()) {
+    if (index === 0) {
+      defaultText = value;
+    }
+    if (key.startsWith("en-")) {
+      return text[key];
+    }
+  }
+
+  return defaultText;
+}
+
+module.exports = { toLanguageObject, getDefaultLanguageString };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,16 @@
 				"ws": "^8.18.0"
 			},
 			"devDependencies": {
+				"ava": "^6.1.3",
 				"eslint": "^8.57.0",
 				"eslint-config-prettier": "9.1.0",
 				"eslint-config-semistandard": "^17.0.0",
 				"eslint-plugin-prettier": "5.2.1",
 				"eslint-plugin-promise": "^6.6.0",
 				"prettier": "^3.3.3"
+			},
+			"engines": {
+				"node": ">=16.18.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -117,6 +121,38 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
 			"integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
 		},
+		"node_modules/@mapbox/node-pre-gyp": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+			"integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+			"dev": true,
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"make-dir": "^3.1.0",
+				"node-fetch": "^2.6.7",
+				"nopt": "^5.0.0",
+				"npmlog": "^5.0.1",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.11"
+			},
+			"bin": {
+				"node-pre-gyp": "bin/node-pre-gyp"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -164,6 +200,43 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -175,6 +248,47 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
+		},
+		"node_modules/@vercel/nft": {
+			"version": "0.26.5",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.26.5.tgz",
+			"integrity": "sha512-NHxohEqad6Ra/r4lGknO52uc/GrWILXAMs1BB4401GTqww0fw1bAqzpG1XHuDO+dprg4GvsD9ZLLSsdo78p9hQ==",
+			"dev": true,
+			"dependencies": {
+				"@mapbox/node-pre-gyp": "^1.0.5",
+				"@rollup/pluginutils": "^4.0.0",
+				"acorn": "^8.6.0",
+				"acorn-import-attributes": "^1.9.2",
+				"async-sema": "^3.1.1",
+				"bindings": "^1.4.0",
+				"estree-walker": "2.0.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.2",
+				"node-gyp-build": "^4.2.2",
+				"resolve-from": "^5.0.0"
+			},
+			"bin": {
+				"nft": "out/cli.js"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@vercel/nft/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
 		"node_modules/acorn": {
@@ -189,6 +303,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/acorn-import-attributes": {
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^8"
+			}
+		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -196,6 +319,30 @@
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.3",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+			"integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -238,6 +385,26 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/aproba": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+			"dev": true
+		},
+		"node_modules/are-we-there-yet": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -259,6 +426,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/array-includes": {
@@ -364,6 +540,164 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/arrgv": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
+			"integrity": "sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/arrify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+			"integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/async-sema": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+			"integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+			"dev": true
+		},
+		"node_modules/ava": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-6.1.3.tgz",
+			"integrity": "sha512-tkKbpF1pIiC+q09wNU9OfyTDYZa8yuWvU2up3+lFJ3lr1RmnYh2GBpPwzYUEB0wvTPIUysGjcZLNZr7STDviRA==",
+			"dev": true,
+			"dependencies": {
+				"@vercel/nft": "^0.26.2",
+				"acorn": "^8.11.3",
+				"acorn-walk": "^8.3.2",
+				"ansi-styles": "^6.2.1",
+				"arrgv": "^1.0.2",
+				"arrify": "^3.0.0",
+				"callsites": "^4.1.0",
+				"cbor": "^9.0.1",
+				"chalk": "^5.3.0",
+				"chunkd": "^2.0.1",
+				"ci-info": "^4.0.0",
+				"ci-parallel-vars": "^1.0.1",
+				"cli-truncate": "^4.0.0",
+				"code-excerpt": "^4.0.0",
+				"common-path-prefix": "^3.0.0",
+				"concordance": "^5.0.4",
+				"currently-unhandled": "^0.4.1",
+				"debug": "^4.3.4",
+				"emittery": "^1.0.1",
+				"figures": "^6.0.1",
+				"globby": "^14.0.0",
+				"ignore-by-default": "^2.1.0",
+				"indent-string": "^5.0.0",
+				"is-plain-object": "^5.0.0",
+				"is-promise": "^4.0.0",
+				"matcher": "^5.0.0",
+				"memoize": "^10.0.0",
+				"ms": "^2.1.3",
+				"p-map": "^7.0.1",
+				"package-config": "^5.0.0",
+				"picomatch": "^3.0.1",
+				"plur": "^5.1.0",
+				"pretty-ms": "^9.0.0",
+				"resolve-cwd": "^3.0.0",
+				"stack-utils": "^2.0.6",
+				"strip-ansi": "^7.1.0",
+				"supertap": "^3.0.1",
+				"temp-dir": "^3.0.0",
+				"write-file-atomic": "^5.0.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"ava": "entrypoints/cli.mjs"
+			},
+			"engines": {
+				"node": "^18.18 || ^20.8 || ^21 || ^22"
+			},
+			"peerDependencies": {
+				"@ava/typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"@ava/typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ava/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ava/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/ava/node_modules/callsites": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.2.0.tgz",
+			"integrity": "sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ava/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/ava/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true
+		},
+		"node_modules/ava/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -386,6 +720,21 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/blueimp-md5": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+			"integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+			"dev": true
+		},
 		"node_modules/bonjour-service": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
@@ -403,6 +752,18 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/builtins": {
@@ -457,6 +818,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/cbor": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+			"integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+			"dev": true,
+			"dependencies": {
+				"nofilter": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -471,6 +844,113 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/chunkd": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
+			"integrity": "sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==",
+			"dev": true
+		},
+		"node_modules/ci-info": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+			"integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ci-parallel-vars": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
+			"integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
+			"dev": true
+		},
+		"node_modules/cli-truncate": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+			"dev": true,
+			"dependencies": {
+				"slice-ansi": "^5.0.0",
+				"string-width": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/code-excerpt": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+			"integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+			"dev": true,
+			"dependencies": {
+				"convert-to-spaces": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/color-convert": {
@@ -491,11 +971,72 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true,
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
+		"node_modules/common-path-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+			"integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+			"dev": true
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/concordance": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+			"integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
+			"dev": true,
+			"dependencies": {
+				"date-time": "^3.1.0",
+				"esutils": "^2.0.3",
+				"fast-diff": "^1.2.0",
+				"js-string-escape": "^1.0.1",
+				"lodash": "^4.17.15",
+				"md5-hex": "^3.0.1",
+				"semver": "^7.3.2",
+				"well-known-symbols": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
+			}
+		},
+		"node_modules/concordance/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"dev": true
+		},
+		"node_modules/convert-to-spaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+			"integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -509,6 +1050,18 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
+			"dev": true,
+			"dependencies": {
+				"array-find-index": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/data-view-buffer": {
@@ -563,6 +1116,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/date-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
+			"integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
+			"dev": true,
+			"dependencies": {
+				"time-zone": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/debug": {
@@ -624,6 +1189,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"dev": true
+		},
+		"node_modules/detect-libc": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dns-packet": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -646,6 +1226,24 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/emittery": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.3.tgz",
+			"integrity": "sha512-tJdCJitoy2lrC2ldJcqN4vkqJ00lT+tOWNT1hBJjO/3FDMJa5TTIiYGCKGkn/WfCyOzUMObeohbVTj00fhiLiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+			"dev": true
 		},
 		"node_modules/es-abstract": {
 			"version": "1.23.3",
@@ -785,6 +1383,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -1218,6 +1825,19 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/esquery": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -1251,6 +1871,12 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1270,6 +1896,34 @@
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -1292,6 +1946,21 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dev": true,
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1302,6 +1971,24 @@
 			},
 			"engines": {
 				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -1315,6 +2002,18 @@
 			},
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -1348,6 +2047,30 @@
 			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
+			}
+		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"dev": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1393,6 +2116,77 @@
 			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/gauge/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/gauge/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gauge/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -1498,6 +2292,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/globby": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+			"dev": true,
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
+				"ignore": "^5.2.4",
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -1510,6 +2324,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -1591,6 +2411,12 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"dev": true
+		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1604,6 +2430,19 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -1611,6 +2450,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/ignore-by-default": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.1.0.tgz",
+			"integrity": "sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10 <11 || >=12 <13 || >=14"
 			}
 		},
 		"node_modules/import-fresh": {
@@ -1636,6 +2484,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -1668,6 +2528,15 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/irregular-plurals": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
+			"integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -1787,6 +2656,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1810,6 +2691,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/is-number-object": {
@@ -1836,6 +2726,21 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"dev": true
 		},
 		"node_modules/is-regex": {
 			"version": "1.1.4",
@@ -1918,6 +2823,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-weakref": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -1943,6 +2860,15 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
+		},
+		"node_modules/js-string-escape": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+			"integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2009,6 +2935,18 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/load-json-file": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-7.0.1.tgz",
+			"integrity": "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2024,11 +2962,132 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"node_modules/make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/matcher": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-5.0.0.tgz",
+			"integrity": "sha512-s2EMBOWtXFc8dgqvoAzKJXxNHibcdJMV0gwqKUaw9E2JBJuGUK7DrNKrA6g/i+v72TT16+6sVm5mS3thaMLQUw==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/matcher/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/md5-hex": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
+			"integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+			"dev": true,
+			"dependencies": {
+				"blueimp-md5": "^2.10.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/memoize": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/memoize/-/memoize-10.0.0.tgz",
+			"integrity": "sha512-H6cBLgsi6vMWOcCpvVCdFFnl3kerEXbrYh9q+lY6VXvQSmM6CkmV08VOwT+WE2tzIEqRPFfAq3fm4v/UIW6mSA==",
+			"dev": true,
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/memoize?sponsor=1"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -2050,6 +3109,52 @@
 			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"dev": true,
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/ms": {
@@ -2075,6 +3180,83 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-gyp-build": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+			"integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
+			"dev": true,
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/nofilter": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+			"integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.19"
+			}
+		},
+		"node_modules/nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"dev": true,
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npmlog": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"deprecated": "This package is no longer supported.",
+			"dev": true,
+			"dependencies": {
+				"are-we-there-yet": "^2.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^3.0.0",
+				"set-blocking": "^2.0.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.2",
@@ -2226,6 +3408,34 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+			"integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/package-config": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/package-config/-/package-config-5.0.0.tgz",
+			"integrity": "sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==",
+			"dev": true,
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"load-json-file": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2236,6 +3446,18 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -2271,6 +3493,45 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+			"integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/plur": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
+			"integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
+			"dev": true,
+			"dependencies": {
+				"irregular-plurals": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.0.0",
@@ -2318,6 +3579,21 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/pretty-ms": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+			"integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
+			"dev": true,
+			"dependencies": {
+				"parse-ms": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2346,6 +3622,20 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.2",
@@ -2379,6 +3669,15 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -2395,6 +3694,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-cwd/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -2474,6 +3794,26 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -2497,10 +3837,42 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/serialize-error": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/serialize-error/node_modules/type-fest": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -2574,6 +3946,132 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/slice-ansi": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^6.0.0",
+				"is-fullwidth-code-point": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/stack-utils/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/string.prototype.trim": {
@@ -2662,6 +4160,70 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/supertap": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/supertap/-/supertap-3.0.1.tgz",
+			"integrity": "sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^5.0.0",
+				"js-yaml": "^3.14.1",
+				"serialize-error": "^7.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/supertap/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/supertap/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/supertap/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/supertap/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2703,6 +4265,32 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
+		"node_modules/tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"dev": true,
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/temp-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2713,6 +4301,33 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+		},
+		"node_modules/time-zone": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+			"integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true
 		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",
@@ -2850,6 +4465,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2857,6 +4484,37 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
+		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true
+		},
+		"node_modules/well-known-symbols": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+			"integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -2911,6 +4569,44 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
+		},
+		"node_modules/wide-align/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wide-align/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2920,11 +4616,82 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
+		},
+		"node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/ws": {
 			"version": "8.18.0",
@@ -2944,6 +4711,77 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"ws": "^8.18.0"
 	},
 	"devDependencies": {
+		"ava": "^6.1.3",
 		"prettier": "^3.3.3",
 		"eslint": "^8.57.0",
 		"eslint-config-prettier": "9.1.0",
@@ -20,9 +21,9 @@
 		"eslint-plugin-promise": "^6.6.0"
 	},
 	"scripts": {
-		"format": "prettier --write lib examples index.js",
-		"lint": "prettier --check lib examples index.js && eslint . --ext .js,.jsx,.ts,.tsx",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"format": "prettier --write \"./{examples,lib,test}/**/*.js\" index.js",
+		"lint": "prettier --check \"./{examples,lib,test}/**/*.js\" index.js && eslint . --ext .js,.jsx,.ts,.tsx",
+		"test": "ava"
 	},
 	"repository": {
 		"type": "git",
@@ -42,5 +43,8 @@
 		"url": "https://github.com/unfoldedcircle/integration-node-library/issues"
 	},
 	"homepage": "https://unfoldedcircle.com",
-	"private": true
+	"private": true,
+	"engines": {
+		"node": ">=16.18.0"
+	}
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,50 @@
+const test = require("ava");
+const { toLanguageObject, getDefaultLanguageString } = require("../lib/utils");
+
+const toLanguageObjectTest = test.macro((t, input, expected) => {
+  const result = toLanguageObject(input);
+  t.deepEqual(result, expected);
+});
+
+test("toLanguageObject with undefined input returns null", toLanguageObjectTest, undefined, null);
+test("toLanguageObject with null input returns null", toLanguageObjectTest, null, null);
+test("toLanguageObject with empty string returns null", toLanguageObjectTest, "", null);
+
+test("toLanguageObject with string returns english text", toLanguageObjectTest, "foobar", { en: "foobar" });
+
+test(
+  "toLanguageObject with Map returns language text",
+  toLanguageObjectTest,
+  new Map([
+    ["en", "foobar"],
+    ["fr", "toto"],
+    ["de-CH", "gugus"],
+    ["de", "dingsbums"]
+  ]),
+  { en: "foobar", fr: "toto", "de-CH": "gugus", de: "dingsbums" }
+);
+
+test(
+  "toLanguageObject with object returns language text",
+  toLanguageObjectTest,
+  { en: "foobar", fr: "toto", "de-CH": "gugus", de: "dingsbums" },
+  { en: "foobar", fr: "toto", "de-CH": "gugus", de: "dingsbums" }
+);
+
+const defaultLanguageString = test.macro((t, input, expected) => {
+  const result = getDefaultLanguageString(input);
+  t.deepEqual(result, expected);
+});
+
+const languageTexts = { en: "foobar", fr: "toto", "de-CH": "gugus", de: "dingsbums" };
+
+test(
+  "getDefaultLanguageString with undefined input returns default text",
+  defaultLanguageString,
+  undefined,
+  "Undefined"
+);
+test("getDefaultLanguageString with null input returns default text", defaultLanguageString, null, "Undefined");
+
+test("getDefaultLanguageString with non-English input returns default text", defaultLanguageString, {}, "Undefined");
+test("getDefaultLanguageString returns English text", defaultLanguageString, languageTexts, "foobar");


### PR DESCRIPTION
Rewrite the driver setup flow handling to use a callback handler instead of events with manual WebSocket interactions in the client.

Rewrite the entity command handler to use a callback handler instead of events. One can install a global entity command handler, or individual ones per entity or entity types.

The callback handlers are modeled the same way as in the Python integration library. If an integration driver doesn't install a callback handler, then the old events are emitted. This should simplify transitioning to the new handlers.
Attention: the old events are planned to be removed by the end of 2024!

Add a new setup-flow example and clean up / simplify the simulated light example.

Add ava testing framework and first utility tests for language strings.

New functionality is currently being tested with the new Global Caché integration which is in development.