### PR TITLE
feat: add remote-entity and UI definitions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,8 +7,7 @@ on:
       - '.github/**/*.yml'
       - 'package-lock.json'
   pull_request:
-    # feature branch for testing only before PR
-    branches: [ "main", "refactor/setup-flow" ]
+    branches: [ "main" ]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Remote-entity and UI definitions.
+- Setup-flow and remote examples.
+
+### Changed
+- Setup handler & entity command handler instead of events (#35).
+- Remove available & configured entity persistence (#34).
+- Remove features parameter from sensor entity constructor.
+
+### Fixed
+- Missing media-player features, options, and commands.
+- Missing options property in available entities.
+
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,13 @@ npm install
 node light.js
 ```
 
+## remote
+
+The [remote-entity example](remote/remote.js) integration shows how to use simple commands, power toggle functionality,
+pre-defined physical button mappings and how to define a user-interface.
+
+The user interface is partially created programmatically, and partially loaded from a json file.  
+
 ## setup-flow
 
 The [setup_flow](setup-flow/setup_flow.js) example shows how to define a dynamic setup flow for the driver setup.

--- a/examples/remote/remote.js
+++ b/examples/remote/remote.js
@@ -1,0 +1,173 @@
+"use strict";
+
+// use package in production
+// const uc = require("uc-integration-api");
+const uc = require("../../index");
+
+const fs = require("fs");
+const { createSendCmd, createSequenceCmd } = require("../../lib/entities/remote");
+
+// Simple commands supported by this example remote entity
+const supportedCommands = [
+  "VOLUME_UP",
+  "VOLUME_DOWN",
+  "HOME",
+  "GUIDE",
+  "CONTEXT_MENU",
+  "CURSOR_UP",
+  "CURSOR_DOWN",
+  "CURSOR_LEFT",
+  "CURSOR_RIGHT",
+  "CURSOR_ENTER",
+  "MY_RECORDINGS",
+  "MY_APPS",
+  "REVERSE",
+  "PLAY",
+  "PAUSE",
+  "FORWARD",
+  "RECORD"
+];
+
+/**
+ * Remote-entity command handler.
+ *
+ * Called by the integration-API if a command is sent to a configured entity.
+ *
+ * @param {uc.Entities.Entity} entity remote entity
+ * @param {string} cmdId command
+ * @param {?Object<string, *>} params optional command parameters
+ * @return {Promise<string>} status of the command
+ */
+const cmdHandler = async (entity, cmdId, params = {}) => {
+  console.log(`Got ${entity.id} command request: ${cmdId}`);
+
+  let state = null;
+  switch (cmdId) {
+    case uc.Entities.Remote.COMMANDS.ON:
+      state = uc.Entities.Remote.STATES.ON;
+      break;
+    case uc.Entities.Remote.COMMANDS.OFF:
+      state = uc.Entities.Remote.STATES.OFF;
+      break;
+    case uc.Entities.Remote.COMMANDS.TOGGLE:
+      state =
+        entity.attributes[uc.Entities.Remote.ATTRIBUTES.STATE] === uc.Entities.Remote.STATES.OFF
+          ? uc.Entities.Remote.STATES.ON
+          : uc.Entities.Remote.STATES.OFF;
+      break;
+    case uc.Entities.Remote.COMMANDS.SEND_CMD: {
+      const command = params.command;
+      // It's up to the integration what to do with an unknown command.
+      // If the supported commands are provided as simple_commands, then it's easy to validate.
+      if (!supportedCommands.includes(command)) {
+        console.error(`Unknown command: ${command}`);
+        return uc.STATUS_CODES.BAD_REQUEST;
+      }
+      const repeat = params.repeat || 1;
+      const delay = params.delay || 0;
+      const hold = params.hold || 0;
+      console.log(`Command: ${command} (repeat=${repeat}, delay=${delay}, hold=${hold})`);
+      break;
+    }
+    case uc.Entities.Remote.COMMANDS.SEND_CMD_SEQUENCE: {
+      const sequence = params.sequence;
+      const seqRepeat = params.repeat || 1;
+      const seqDelay = params.delay || 0;
+      console.log(`Command sequence: ${sequence} (repeat=${seqRepeat}, delay=${seqDelay})`);
+      break;
+    }
+    default:
+      console.error(`Unsupported command: ${cmdId}`);
+      return uc.STATUS_CODES.BAD_REQUEST;
+  }
+
+  if (state) {
+    const newState = {};
+    newState[uc.Entities.Remote.ATTRIBUTES.STATE] = state;
+    // const newState = new Map([
+    //   [uc.Entities.Remote.ATTRIBUTES.STATE, state]
+    // ])
+    uc.configuredEntities.updateEntityAttributes(entity.id, newState);
+  }
+
+  return uc.STATUS_CODES.OK;
+};
+
+// Event listener for connection event
+uc.on(uc.EVENTS.CONNECT, async () => {
+  // When connected, set device state to CONNECTED
+  await uc.setDeviceState(uc.DEVICE_STATES.CONNECTED);
+});
+
+uc.on(uc.EVENTS.DISCONNECT, async () => {
+  await uc.setDeviceState(uc.DEVICE_STATES.DISCONNECTED);
+});
+
+// Create button mappings
+const createButtonMappings = () => {
+  return [
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.HOME, "HOME", "GUIDE"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.CHANNEL_DOWN, "VOLUME_DOWN"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.CHANNEL_UP, "VOLUME_UP"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_UP, "CURSOR_UP"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_DOWN, "CURSOR_DOWN"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_LEFT, "CURSOR_LEFT"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_RIGHT, "CURSOR_RIGHT"),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_MIDDLE, createSendCmd("CONTEXT_MENU", undefined, undefined, 100)),
+    uc.ui.createBtnMapping(
+      uc.ui.BUTTONS.BLUE,
+      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], 200)
+    ),
+    { button: "POWER", short_press: { cmd_id: "remote.toggle" } }
+  ];
+};
+
+// Create UI pages
+const createUi = () => {
+  const mainPage = JSON.parse(fs.readFileSync("remote_ui_page.json", "utf-8"));
+
+  const uiPage1 = new uc.ui.UiPage("page1", "Main");
+  uiPage1.add(uc.ui.createUiText("Hello remote entity", 0, 0, undefined, new uc.ui.Size(4, 1)));
+  uiPage1.add(uc.ui.createUiIcon("uc:home", 0, 2, "HOME"));
+  uiPage1.add(uc.ui.createUiIcon("uc:up-arrow-bold", 2, 2, "CURSOR_UP"));
+  uiPage1.add(uc.ui.createUiIcon("uc:down-arrow-bold", 2, 4, "CURSOR_DOWN"));
+  uiPage1.add(uc.ui.createUiIcon("uc:left-arrow", 1, 3, "CURSOR_LEFT"));
+  uiPage1.add(uc.ui.createUiIcon("uc:right-arrow", 3, 3, "CURSOR_RIGHT"));
+  uiPage1.add(uc.ui.createUiText("Ok", 2, 3, "CURSOR_ENTER"));
+
+  const uiPage2 = new uc.ui.UiPage("page2", "Page 2");
+  uiPage2.add(
+    uc.ui.createUiText("Pump up the volume!", 0, 0, createSendCmd("VOLUME_UP", { repeat: 5 }), new uc.ui.Size(4, 2))
+  );
+  uiPage2.add(
+    uc.ui.createUiText(
+      "Test sequence",
+      0,
+      4,
+      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], 200),
+      new uc.ui.Size(4, 1)
+    )
+  );
+  uiPage2.add(uc.ui.createUiText("On", 0, 5, "on"));
+  uiPage2.add(uc.ui.createUiText("Off", 1, 5, "off"));
+
+  return [mainPage, uiPage1, uiPage2];
+};
+
+// -- startup driver
+
+const entity = new uc.Entities.Remote(
+  "remote1",
+  "Demo remote",
+  [uc.Entities.Remote.FEATURES.ON_OFF, uc.Entities.Remote.FEATURES.TOGGLE],
+  new Map([[uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF]]),
+  supportedCommands,
+  createButtonMappings(),
+  createUi(),
+  "test lab",
+  cmdHandler
+);
+
+uc.availableEntities.addEntity(entity);
+
+uc.init("remote.json");

--- a/examples/remote/remote.js
+++ b/examples/remote/remote.js
@@ -113,10 +113,10 @@ const createButtonMappings = () => {
     uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_DOWN, "CURSOR_DOWN"),
     uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_LEFT, "CURSOR_LEFT"),
     uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_RIGHT, "CURSOR_RIGHT"),
-    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_MIDDLE, createSendCmd("CONTEXT_MENU", undefined, undefined, 100)),
+    uc.ui.createBtnMapping(uc.ui.BUTTONS.DPAD_MIDDLE, createSendCmd("CONTEXT_MENU", { hold: 100 })),
     uc.ui.createBtnMapping(
       uc.ui.BUTTONS.BLUE,
-      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], 200)
+      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 })
     ),
     { button: "POWER", short_press: { cmd_id: "remote.toggle" } }
   ];
@@ -144,7 +144,7 @@ const createUi = () => {
       "Test sequence",
       0,
       4,
-      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], 200),
+      createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 }),
       new uc.ui.Size(4, 1)
     )
   );
@@ -156,17 +156,14 @@ const createUi = () => {
 
 // -- startup driver
 
-const entity = new uc.Entities.Remote(
-  "remote1",
-  "Demo remote",
-  [uc.Entities.Remote.FEATURES.ON_OFF, uc.Entities.Remote.FEATURES.TOGGLE],
-  new Map([[uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF]]),
-  supportedCommands,
-  createButtonMappings(),
-  createUi(),
-  "test lab",
+const entity = new uc.Entities.Remote("remote1", "Demo remote", {
+  features: [uc.Entities.Remote.FEATURES.ON_OFF, uc.Entities.Remote.FEATURES.TOGGLE],
+  attributes: new Map([[uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF]]),
+  simpleCommands: supportedCommands,
+  buttonMapping: createButtonMappings(),
+  uiPages: createUi(),
   cmdHandler
-);
+});
 
 uc.availableEntities.addEntity(entity);
 

--- a/examples/remote/remote.json
+++ b/examples/remote/remote.json
@@ -1,0 +1,18 @@
+{
+  "driver_id": "remote_test_js",
+  "version": "0.0.1",
+  "min_core_api": "0.20.0",
+  "name": { "en": "Remote test Node.js" },
+  "icon": "uc:integration",
+  "description": {
+    "en": "Minimal Node.js integration driver example with a remote entity."
+  },
+  "port": 9084,
+  "developer": {
+    "name": "Unfolded Circle ApS",
+    "email": "hello@unfoldedcircle.com",
+    "url": "https://www.unfoldedcircle.com"
+  },
+  "home_page": "https://www.unfoldedcircle.com",
+  "release_date": "2024-08-13"
+}

--- a/examples/remote/remote_ui_page.json
+++ b/examples/remote/remote_ui_page.json
@@ -1,0 +1,65 @@
+{
+  "page_id": "media",
+  "name": "Media",
+  "grid": { "width": 4, "height": 6 },
+  "items": [
+    {
+      "type": "text",
+      "text": "Recordings",
+      "command": {
+        "cmd_id": "MY_RECORDINGS"
+      },
+      "location": { "x": 0, "y": 2 },
+      "size": { "width": 2, "height": 1 }
+    },
+    {
+      "type": "text",
+      "text": "Apps",
+      "command": {
+        "cmd_id": "MY_APPS"
+      },
+      "location": { "x": 2, "y": 2 },
+      "size": { "width": 2, "height": 1 }
+    },
+    {
+      "type": "icon",
+      "icon": "uc:bw",
+      "command": {
+        "cmd_id": "REVERSE"
+      },
+      "location": { "x": 0, "y": 5 }
+    },
+    {
+      "type": "icon",
+      "icon": "uc:play",
+      "command": {
+        "cmd_id": "PLAY"
+      },
+      "location": { "x": 1, "y": 5 }
+    },
+    {
+      "type": "icon",
+      "icon": "uc:pause",
+      "command": {
+        "cmd_id": "PAUSE"
+      },
+      "location": { "x": 2, "y": 5 }
+    },
+    {
+      "type": "icon",
+      "icon": "uc:ff",
+      "command": {
+        "cmd_id": "FORWARD"
+      },
+      "location": { "x": 3, "y": 5 }
+    },
+    {
+      "type": "icon",
+      "icon": "uc:rec",
+      "command": {
+        "cmd_id": "RECORD"
+      },
+      "location": { "x": 2, "y": 4 }
+    }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class IntegrationAPI extends EventEmitter {
       const data = {
         entity_id: entityId,
         entity_type: entityType,
-        attributes: Object.fromEntries(attributes)
+        attributes: attributes instanceof Map ? Object.fromEntries(attributes) : attributes
       };
 
       await this.#broadcastEvent(uc.MSG_EVENTS.ENTITY_CHANGE, data, uc.EVENT_CATEGORY.ENTITY);
@@ -768,3 +768,4 @@ module.exports.EVENTS = uc.EVENTS;
 module.exports.STATUS_CODES = uc.STATUS_CODES;
 module.exports.Entities = Entities;
 module.exports.setup = uc.setup;
+module.exports.ui = require("./lib/entities/ui");

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -46,11 +46,12 @@ class Button extends Entity {
    * Constructs a new button entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.   * @param id
-   * @param {string} area Optional area or room.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, area = undefined, cmdHandler = undefined) {
+  constructor(id, name, area, cmdHandler = null) {
     super(
       id,
       name,

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -52,17 +52,12 @@ class Button extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, area, cmdHandler = null) {
-    super(
-      id,
-      name,
-      Entity.TYPES.BUTTON,
-      ["press"],
-      new Map([[ATTRIBUTES.STATE, STATES.AVAILABLE]]),
-      undefined,
-      null,
+    super(id, name, Entity.TYPES.BUTTON, {
+      features: ["press"],
+      attributes: new Map([[ATTRIBUTES.STATE, STATES.AVAILABLE]]),
       area,
       cmdHandler
-    );
+    });
 
     console.debug(`Button entity created with id: ${this.id}`);
   }

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -97,24 +97,16 @@ class Climate extends Entity {
    * Constructs a new climate entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string[]} features Optional entity features.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    features,
-    attributes,
-    deviceClass = undefined,
-    options = null,
-    area = undefined,
-    cmdHandler = undefined
-  ) {
+  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
     super(id, name, Entity.TYPES.CLIMATE, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Climate entity created with id: ${this.id}`);

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -107,7 +107,7 @@ class Climate extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
-    super(id, name, Entity.TYPES.CLIMATE, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.CLIMATE, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Climate entity created with id: ${this.id}`);
   }

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -106,7 +106,7 @@ class Cover extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
-    super(id, name, Entity.TYPES.COVER, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.COVER, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Cover entity created with id: ${this.id}`);
   }

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -96,24 +96,16 @@ class Cover extends Entity {
    * Constructs a new cover entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string[]} features Optional entity features.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    features,
-    attributes,
-    deviceClass = undefined,
-    options = null,
-    area = undefined,
-    cmdHandler = undefined
-  ) {
+  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
     super(id, name, Entity.TYPES.COVER, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Cover entity created with id: ${this.id}`);

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -14,6 +14,7 @@ const Climate = require("./climate");
 const Cover = require("./cover");
 const Light = require("./light");
 const MediaPlayer = require("./media_player");
+const Remote = require("./remote");
 const Sensor = require("./sensor");
 const Switch = require("./switch");
 const { EVENTS } = require("../api_definitions");
@@ -26,17 +27,6 @@ class Entities extends EventEmitter {
 
     this.id = id;
     this.#storage = {};
-  }
-
-  static generateId(prefix = "entity") {
-    return (
-      prefix +
-      "_" +
-      Array(25)
-        .fill()
-        .map(() => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(Math.random() * 62))
-        .join("")
-    );
   }
 
   contains(id) {
@@ -78,8 +68,8 @@ class Entities extends EventEmitter {
   /**
    * Update or merge the provided attributes into an entity.
    *
-   * @param {String} id The entity_id
-   * @param {Map} attributes The attributes to merge into the entity's attributes
+   * @param {string} id The entity_id
+   * @param {Map<string,string>|Object<string,string>} attributes The attributes to merge into the entity's attributes
    * @returns {boolean} false if entity doesn't exist, true if attributes were merged.
    */
   updateEntityAttributes(id, attributes) {
@@ -87,9 +77,15 @@ class Entities extends EventEmitter {
       return false;
     }
 
-    attributes.forEach((value, key) => {
-      this.#storage[id].attributes[key] = value;
-    });
+    if (attributes instanceof Map) {
+      attributes.forEach((value, key) => {
+        this.#storage[id].attributes[key] = value;
+      });
+    } else {
+      for (const key in attributes) {
+        this.#storage[id].attributes[key] = attributes[key];
+      }
+    }
 
     this.emit(EVENTS.ENTITY_ATTRIBUTES_UPDATED, id, this.#storage[id].entity_type, attributes);
 
@@ -147,5 +143,6 @@ module.exports.Climate = Climate;
 module.exports.Cover = Cover;
 module.exports.Light = Light;
 module.exports.MediaPlayer = MediaPlayer;
+module.exports.Remote = Remote;
 module.exports.Sensor = Sensor;
 module.exports.Switch = Switch;

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -34,17 +34,25 @@ class Entity {
    * Constructs a new entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {string|Map} name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string} entityType One of defined [Entity.TYPES]{@link TYPES}.
-   * @param {string[]} features Optional entity features.
-   * @param {Map | null} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object | null} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {Object} params entity parameters
+   * @param {string[]} [params.features=[]] Optional entity features.
+   * @param {Map | null} params.attributes Optional entity attribute Map holding the current state.
+   * @param {string} [params.deviceClass] Optional device class.
+   * @param {object | null} [params.options=null] Further options. See entity documentation.
+   * @param {string} [params.area] Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, entityType, features, attributes, deviceClass, options, area, cmdHandler = null) {
+  constructor(
+    id,
+    name,
+    entityType,
+    { features = [], attributes = null, deviceClass, options = null, area, cmdHandler = null } = {}
+  ) {
     assert(typeof id === "string", "Entity parameter id must be a string");
     this.id = id;
     this.name = toLanguageObject(name);

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -14,7 +14,7 @@ const assert = require("node:assert");
 /**
  * Available entity types.
  *
- * @type {{COVER: string, BUTTON: string, LIGHT: string, SENSOR: string, MEDIA_PLAYER: string, SWITCH: string, CLIMATE: string}}
+ * @type {{COVER: string, BUTTON: string, LIGHT: string, SENSOR: string, MEDIA_PLAYER: string, REMOTE: string, SWITCH: string, CLIMATE: string}}
  */
 const TYPES = {
   COVER: "cover",
@@ -22,6 +22,7 @@ const TYPES = {
   CLIMATE: "climate",
   LIGHT: "light",
   MEDIA_PLAYER: "media_player",
+  REMOTE: "remote",
   SENSOR: "sensor",
   SWITCH: "switch"
 };
@@ -33,16 +34,17 @@ class Entity {
    * Constructs a new entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string} entityType One of defined [Entity.TYPES]{@link TYPES}.
    * @param {string[]} features Optional entity features.
    * @param {Map | null} attributes Optional entity attribute Map holding the current state.
-   * @param {string | undefined} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object | null} options Further options. See entity documentation.
-   * @param {string | undefined} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, entityType, features, attributes, deviceClass, options, area, cmdHandler = undefined) {
+  constructor(id, name, entityType, features, attributes, deviceClass, options, area, cmdHandler = null) {
     assert(typeof id === "string", "Entity parameter id must be a string");
     this.id = id;
     this.name = toLanguageObject(name);
@@ -62,10 +64,7 @@ class Entity {
     this.options = options;
     assert(area === undefined || typeof area === "string", "Entity parameter area must be a string");
     this.area = area;
-    assert(
-      cmdHandler === undefined || typeof cmdHandler === "function",
-      "Entity parameter cmdHandler must be a function"
-    );
+    assert(cmdHandler === null || typeof cmdHandler === "function", "Entity parameter cmdHandler must be a function");
     this.#cmdHandler = cmdHandler;
   }
 

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -80,24 +80,16 @@ class Light extends Entity {
    * Constructs a new light entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string[]} features Optional entity features.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    features,
-    attributes,
-    deviceClass = undefined,
-    options = null,
-    area = undefined,
-    cmdHandler = undefined
-  ) {
+  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
     super(id, name, Entity.TYPES.LIGHT, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Light entity created with id: ${this.id}`);

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -90,7 +90,7 @@ class Light extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
-    super(id, name, Entity.TYPES.LIGHT, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.LIGHT, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Light entity created with id: ${this.id}`);
   }

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -217,24 +217,16 @@ class MediaPlayer extends Entity {
    * Constructs a new media-player entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string[]} features Optional entity features.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    features,
-    attributes,
-    deviceClass = undefined,
-    options = null,
-    area = undefined,
-    cmdHandler = undefined
-  ) {
+  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
     super(id, name, Entity.TYPES.MEDIA_PLAYER, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`MediaPlayer entity created with id: ${this.id}`);

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -227,7 +227,7 @@ class MediaPlayer extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
-    super(id, name, Entity.TYPES.MEDIA_PLAYER, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.MEDIA_PLAYER, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`MediaPlayer entity created with id: ${this.id}`);
   }

--- a/lib/entities/remote.js
+++ b/lib/entities/remote.js
@@ -71,13 +71,14 @@ const OPTIONS = {
 /**
  * Create a remote-entity send command.
  * @param {string} command command to send.
- * @param {number} [delay] optional delay in milliseconds after the command or between repeats.
- * @param {number} [repeat] optional repeat count of the command.
- * @param {number} [hold] optional hold time in milliseconds.
+ * @param {Object} [params] optional named parameters
+ * @param {number} [params.delay] optional delay in milliseconds after the command or between repeats.
+ * @param {number} [params.repeat] optional repeat count of the command.
+ * @param {number} [params.hold] optional hold time in milliseconds.
  * @return {EntityCommand} the created EntityCommand.
  * @throws AssertionError if command is not specified or is empty.
  */
-function createSendCmd(command, delay, repeat, hold) {
+function createSendCmd(command, { delay, repeat, hold } = {}) {
   assert(command && typeof command === "string" && command.length > 0, "command must be a string and may not be empty");
   const params = { command };
   if (typeof delay === "number") {
@@ -95,12 +96,13 @@ function createSendCmd(command, delay, repeat, hold) {
 /**
  * Create a remote send sequence command.
  * @param {Array<string>} sequence list of simple commands. An empty array is not valid.
- * @param {number} [delay] optional delay in milliseconds between the commands in the sequence.
- * @param {number} [repeat] optional repeat count of the sequence.
+ * @param {Object} [params] optional named parameters
+ * @param {number} [params.delay] optional delay in milliseconds between the commands in the sequence.
+ * @param {number} [params.repeat] optional repeat count of the sequence.
  * @return {EntityCommand} the created EntityCommand.
  * @throws AssertionError if sequence is not specified or doesn't contain at least one command.
  */
-function createSequenceCmd(sequence, delay, repeat) {
+function createSequenceCmd(sequence, { delay, repeat } = {}) {
   assert(
     sequence && sequence instanceof Array && sequence.length > 0,
     "sequence array must be specified and contain at least one command"
@@ -120,17 +122,24 @@ class Remote extends Entity {
    * Constructs a new remote-entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {Array<string>} features - remote features.
-   * @param {Map} attributes remote attributes.
-   * @param {Array<string>} [simpleCommands] Optional list of supported remote command identifiers.
-   * @param {Array<DeviceButtonMapping|Object<string, *>>} [buttonMapping] Optional command mapping of physical buttons.
-   * @param {Array<UiPage|Object<string, *>>} [uiPages] Optional user interface page definitions.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] optional named parameters
+   * @param {Array<string>} params.features - remote features.
+   * @param {Map} params.attributes remote attributes.
+   * @param {Array<string>} [params.simpleCommands] Optional list of supported remote command identifiers.
+   * @param {Array<DeviceButtonMapping|Object<string, *>>} [params.buttonMapping] Optional command mapping of physical buttons.
+   * @param {Array<UiPage|Object<string, *>>} [params.uiPages] Optional user interface page definitions.
+   * @param {string} [params.area] Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} params.cmdHandler
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler = null) {
+  constructor(
+    id,
+    name,
+    { features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler = null } = {}
+  ) {
     const options = {};
     if (simpleCommands) {
       options[OPTIONS.SIMPLE_COMMANDS] = simpleCommands;
@@ -141,8 +150,7 @@ class Remote extends Entity {
     if (uiPages) {
       options[OPTIONS.USER_INTERFACE] = { pages: uiPages };
     }
-    const deviceClass = undefined;
-    super(id, name, Entity.TYPES.REMOTE, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.REMOTE, { features, attributes, options, area, cmdHandler });
   }
 }
 

--- a/lib/entities/remote.js
+++ b/lib/entities/remote.js
@@ -1,0 +1,156 @@
+/**
+ * Remote-entity definitions.
+ * See <https://github.com/unfoldedcircle/core-api/tree/main/doc/entities> for more information.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Apache License 2.0, see LICENSE for more details.
+ */
+"use strict";
+
+const { EntityCommand } = require("./ui");
+
+const Entity = require("./entity");
+const assert = require("node:assert");
+
+/**
+ * Remote entity states.
+ *
+ * @type {{UNAVAILABLE: string, UNKNOWN: string, OFF: string, ON: string}}
+ */
+const STATES = {
+  UNAVAILABLE: "UNAVAILABLE",
+  UNKNOWN: "UNKNOWN",
+  ON: "ON",
+  OFF: "OFF"
+};
+
+/**
+ * Remote-entity features.
+ *
+ * @type {{SEND_CMD: string, TOGGLE: string, ON_OFF: string}}
+ */
+const FEATURES = {
+  ON_OFF: "on_off",
+  TOGGLE: "toggle",
+  SEND_CMD: "send_cmd"
+};
+
+/**
+ * Remote-entity attributes.
+ *
+ * @type {{STATE: string}}
+ */
+const ATTRIBUTES = {
+  STATE: "state"
+};
+
+/**
+ * Remote-entity commands.
+ *
+ * @type {{SEND_CMD: string, SEND_CMD_SEQUENCE: string, TOGGLE: string, OFF: string, ON: string}}
+ */
+const COMMANDS = {
+  ON: "on",
+  OFF: "off",
+  TOGGLE: "toggle",
+  SEND_CMD: "send_cmd",
+  SEND_CMD_SEQUENCE: "send_cmd_sequence"
+};
+
+/**
+ * Remote-entity-options.
+ *
+ * @type {{SIMPLE_COMMANDS: string, USER_INTERFACE: string, BUTTON_MAPPING: string}}
+ */
+const OPTIONS = {
+  SIMPLE_COMMANDS: "simple_commands",
+  BUTTON_MAPPING: "button_mapping",
+  USER_INTERFACE: "user_interface"
+};
+
+/**
+ * Create a remote-entity send command.
+ * @param {string} command command to send.
+ * @param {number} [delay] optional delay in milliseconds after the command or between repeats.
+ * @param {number} [repeat] optional repeat count of the command.
+ * @param {number} [hold] optional hold time in milliseconds.
+ * @return {EntityCommand} the created EntityCommand.
+ * @throws AssertionError if command is not specified or is empty.
+ */
+function createSendCmd(command, delay, repeat, hold) {
+  assert(command && typeof command === "string" && command.length > 0, "command must be a string and may not be empty");
+  const params = { command };
+  if (typeof delay === "number") {
+    params.delay = delay;
+  }
+  if (typeof repeat === "number") {
+    params.repeat = repeat;
+  }
+  if (typeof hold === "number") {
+    params.hold = hold;
+  }
+  return new EntityCommand(COMMANDS.SEND_CMD, params);
+}
+
+/**
+ * Create a remote send sequence command.
+ * @param {Array<string>} sequence list of simple commands. An empty array is not valid.
+ * @param {number} [delay] optional delay in milliseconds between the commands in the sequence.
+ * @param {number} [repeat] optional repeat count of the sequence.
+ * @return {EntityCommand} the created EntityCommand.
+ * @throws AssertionError if sequence is not specified or doesn't contain at least one command.
+ */
+function createSequenceCmd(sequence, delay, repeat) {
+  assert(
+    sequence && sequence instanceof Array && sequence.length > 0,
+    "sequence array must be specified and contain at least one command"
+  );
+  const params = { sequence };
+  if (typeof delay === "number") {
+    params.delay = delay;
+  }
+  if (typeof repeat === "number") {
+    params.repeat = repeat;
+  }
+  return new EntityCommand(COMMANDS.SEND_CMD_SEQUENCE, params);
+}
+
+class Remote extends Entity {
+  /**
+   * Constructs a new remote-entity.
+   *
+   * @param {string} id The entity identifier. Must be unique inside the integration driver.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Array<string>} features - remote features.
+   * @param {Map} attributes remote attributes.
+   * @param {Array<string>} [simpleCommands] Optional list of supported remote command identifiers.
+   * @param {Array<DeviceButtonMapping|Object<string, *>>} [buttonMapping] Optional command mapping of physical buttons.
+   * @param {Array<UiPage|Object<string, *>>} [uiPages] Optional user interface page definitions.
+   * @param {string} [area] Optional area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
+   */
+  constructor(id, name, features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler = null) {
+    const options = {};
+    if (simpleCommands) {
+      options[OPTIONS.SIMPLE_COMMANDS] = simpleCommands;
+    }
+    if (buttonMapping) {
+      options[OPTIONS.BUTTON_MAPPING] = buttonMapping;
+    }
+    if (uiPages) {
+      options[OPTIONS.USER_INTERFACE] = { pages: uiPages };
+    }
+    const deviceClass = undefined;
+    super(id, name, Entity.TYPES.REMOTE, features, attributes, deviceClass, options, area, cmdHandler);
+  }
+}
+
+module.exports = Remote;
+module.exports.createSendCmd = createSendCmd;
+module.exports.createSequenceCmd = createSequenceCmd;
+module.exports.STATES = STATES;
+module.exports.FEATURES = FEATURES;
+module.exports.ATTRIBUTES = ATTRIBUTES;
+module.exports.COMMANDS = COMMANDS;
+module.exports.OPTIONS = OPTIONS;

--- a/lib/entities/sensor.js
+++ b/lib/entities/sensor.js
@@ -91,7 +91,7 @@ class Sensor extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, attributes, deviceClass, options = null, area) {
-    super(id, name, Entity.TYPES.SENSOR, [], attributes, deviceClass, options, area);
+    super(id, name, Entity.TYPES.SENSOR, { attributes, deviceClass, options, area });
 
     console.debug(`Sensor entity created with id: ${this.id}`);
   }

--- a/lib/entities/sensor.js
+++ b/lib/entities/sensor.js
@@ -83,13 +83,14 @@ class Sensor extends Entity {
    * Constructs a new sensor entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, attributes, deviceClass = undefined, options = null, area = undefined) {
+  constructor(id, name, attributes, deviceClass, options = null, area) {
     super(id, name, Entity.TYPES.SENSOR, [], attributes, deviceClass, options, area);
 
     console.debug(`Sensor entity created with id: ${this.id}`);

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -87,7 +87,7 @@ class Switch extends Entity {
    * @throws AssertionError if invalid parameters are specified.
    */
   constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
-    super(id, name, Entity.TYPES.SWITCH, features, attributes, deviceClass, options, area, cmdHandler);
+    super(id, name, Entity.TYPES.SWITCH, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Switch entity created with id: ${this.id}`);
   }

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -77,24 +77,16 @@ class Switch extends Entity {
    * Constructs a new switch entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string|Map} name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map containing multiple language strings.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string[]} features Optional entity features.
    * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} deviceClass Optional device class.
+   * @param {string} [deviceClass] Optional device class.
    * @param {object} options Further options. See entity documentation.
-   * @param {string} area Optional area or room.
+   * @param {string} [area] Optional area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    features,
-    attributes,
-    deviceClass = undefined,
-    options = null,
-    area = undefined,
-    cmdHandler = undefined
-  ) {
+  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
     super(id, name, Entity.TYPES.SWITCH, features, attributes, deviceClass, options, area, cmdHandler);
 
     console.debug(`Switch entity created with id: ${this.id}`);

--- a/lib/entities/ui.js
+++ b/lib/entities/ui.js
@@ -133,16 +133,19 @@ class Location {
  */
 class UiItem {
   /**
-   * Constructs a new UiItem
+   * Constructs a new UiItem.
+   *
+   * One of `icon` or `text` must be specified. The default item size is 1x1 if not specified.
    * @param {string} type - Type of the UI item ("icon" or "text").
    * @param {Location} location - Location of the item in the grid.
-   * @param {Size} [size] - Size of the item.
-   * @param {string} [icon] - Icon identifier.
-   * @param {string} [text] - Text to display.
-   * @param {EntityCommand} [command] - Associated command.
+   * @param {Object} params optional named parameters
+   * @param {Size} [params.size] - Size of the item.
+   * @param {string} [params.icon] - Icon identifier.
+   * @param {string} [params.text] - Text to display.
+   * @param {EntityCommand} [params.command] - Associated command.
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(type, location, size, icon, text, command) {
+  constructor(type, location, { size, icon, text, command }) {
     assert(location instanceof Location, "location parameter must be of type Location");
     assert(size === undefined || size instanceof Size, "size parameter must be of type Size");
     assert(icon === undefined || typeof icon === "string", "icon parameter must be of type string");
@@ -165,18 +168,18 @@ class UiItem {
  * @param {string} text the text to show in the UI item.
  * @param {number} x x-position, 0-based.
  * @param {number} y y-position, 0-based.
- * @param {string|EntityCommand} [cmd] associated command to the text item. A string parameter corresponds to
+ * @param {string|EntityCommand} [command] associated command to the text item. A string parameter corresponds to
  *            a simple command, whereas an ``EntityCommand`` allows to customize the
  *            command for example with number of repeats.
  * @param {Size} [size] item size, defaults to 1 x 1 if not specified.
  * @return {UiItem} the created UiItem
  * @throws AssertionError if invalid parameters are specified.
  */
-function createUiText(text, x, y, cmd, size) {
-  if (typeof cmd === "string") {
-    cmd = new EntityCommand(cmd);
+function createUiText(text, x, y, command, size) {
+  if (typeof command === "string") {
+    command = new EntityCommand(command);
   }
-  return new UiItem("text", new Location(x, y), size, undefined, text, cmd);
+  return new UiItem("text", new Location(x, y), { size, text, command });
 }
 
 /**
@@ -189,18 +192,18 @@ function createUiText(text, x, y, cmd, size) {
  * @param {string} icon the icon identifier of the icon to show in the UI item.
  * @param {number} x x-position, 0-based.
  * @param {number} y y-position, 0-based.
- * @param {string|EntityCommand} [cmd] associated command to the text item. A string parameter corresponds to
+ * @param {string|EntityCommand} [command] associated command to the text item. A string parameter corresponds to
  *            a simple command, whereas an `EntityCommand` allows to customize the
  *            command for example with number of repeats.
  * @param {Size} [size] item size, defaults to 1 x 1 if not specified.
  * @return {UiItem} the created UiItem
  * @throws AssertionError if invalid parameters are specified.
  */
-function createUiIcon(icon, x, y, cmd, size) {
-  if (typeof cmd === "string") {
-    cmd = new EntityCommand(cmd);
+function createUiIcon(icon, x, y, command, size) {
+  if (typeof command === "string") {
+    command = new EntityCommand(command);
   }
-  return new UiItem("icon", new Location(x, y), size, icon, undefined, cmd);
+  return new UiItem("icon", new Location(x, y), { size, icon, command });
 }
 
 /**

--- a/lib/entities/ui.js
+++ b/lib/entities/ui.js
@@ -1,0 +1,246 @@
+/**
+ * User interface definitions.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Apache License 2.0, see LICENSE for more details.
+ */
+
+const assert = require("node:assert");
+/**
+ * Physical buttons.
+ * @type {{CHANNEL_UP: string, BLUE: string, POWER: string, VOLUME_DOWN: string, GREEN: string, RED: string, PLAY: string, VOICE: string, DPAD_UP: string, DPAD_DOWN: string, PREV: string, DPAD_RIGHT: string, NEXT: string, BACK: string, DPAD_MIDDLE: string, CHANNEL_DOWN: string, YELLOW: string, VOLUME_UP: string, MUTE: string, HOME: string, DPAD_LEFT: string}}
+ */
+const BUTTONS = {
+  BACK: "BACK",
+  HOME: "HOME",
+  VOICE: "VOICE",
+  VOLUME_UP: "VOLUME_UP",
+  VOLUME_DOWN: "VOLUME_DOWN",
+  MUTE: "MUTE",
+  DPAD_UP: "DPAD_UP",
+  DPAD_DOWN: "DPAD_DOWN",
+  DPAD_LEFT: "DPAD_LEFT",
+  DPAD_RIGHT: "DPAD_RIGHT",
+  DPAD_MIDDLE: "DPAD_MIDDLE",
+  GREEN: "GREEN",
+  YELLOW: "YELLOW",
+  RED: "RED",
+  BLUE: "BLUE",
+  CHANNEL_UP: "CHANNEL_UP",
+  CHANNEL_DOWN: "CHANNEL_DOWN",
+  PREV: "PREV",
+  PLAY: "PLAY",
+  NEXT: "NEXT",
+  POWER: "POWER"
+};
+
+/**
+ * Remote command definition for a button mapping or UI page definition.
+ */
+class EntityCommand {
+  /**
+   * Constructs a new EntityCommand.
+   * @param {string} cmdId - Command identifier.
+   * @param {Object.<string, (string|number|Array<string>)>} [params] - Optional parameters for the command.
+   */
+  constructor(cmdId, params) {
+    this.cmd_id = cmdId;
+    this.params = params;
+  }
+}
+
+/**
+ * Physical button command mapping.
+ */
+class DeviceButtonMapping {
+  /**
+   * Constructs a new Physical button command mapping.
+   * @param {string} button - Physical button identifier.
+   * @param {EntityCommand} [shortPress] - Short press command of the button.
+   * @param {EntityCommand} [longPress] - Long press command of the button.
+   * @throws AssertionError if shortPress or longPress arguments are of a wrong type.
+   */
+  constructor(button, shortPress, longPress) {
+    assert(
+      shortPress === undefined || shortPress instanceof EntityCommand,
+      "shortPress parameter must be an EntityCommand"
+    );
+    assert(
+      longPress === undefined || longPress instanceof EntityCommand,
+      "longPress parameter must be an EntityCommand"
+    );
+    this.button = button;
+    this.short_press = shortPress;
+    this.long_press = longPress;
+  }
+}
+
+/**
+ * Create a physical button command mapping.
+ * @param {string} button physical button identifier, one of {@link BUTTONS}.
+ * @param {string|EntityCommand} [short] associated short-press command to the physical button.
+ *              A string parameter corresponds to a simple command, whereas an
+ *              ``EntityCommand`` allows to customize the command.
+ * @param {string|EntityCommand} [long] associated long-press command to the physical button
+ * @return {DeviceButtonMapping} the created DeviceButtonMapping
+ * @throws AssertionError if shortPress or longPress arguments are of a wrong type.
+ */
+function createBtnMapping(button, short, long) {
+  if (typeof short === "string") {
+    short = new EntityCommand(short);
+  }
+  if (typeof long === "string") {
+    long = new EntityCommand(long);
+  }
+  return new DeviceButtonMapping(button, short, long);
+}
+
+/**
+ * Item size in the button grid. Default size if not specified: 1x1.
+ */
+class Size {
+  /**
+   * Constructs a new Size.
+   * @param {number} [width=1] - Width of the item.
+   * @param {number} [height=1] - Height of the item.
+   */
+  constructor(width = 1, height = 1) {
+    this.width = width;
+    this.height = height;
+  }
+}
+
+/**
+ * Button placement in the grid with 0-based coordinates.
+ */
+class Location {
+  /**
+   * Constructs a new Location.
+   * @param {number} x - X coordinate.
+   * @param {number} y - Y coordinate.
+   */
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+/**
+ * A user interface item is either an icon or text.
+ *
+ * - Icon and text items can be static or linked to a command specified in the `command` field.
+ * - Default size is 1x1 if not specified.
+ */
+class UiItem {
+  /**
+   * Constructs a new UiItem
+   * @param {string} type - Type of the UI item ("icon" or "text").
+   * @param {Location} location - Location of the item in the grid.
+   * @param {Size} [size] - Size of the item.
+   * @param {string} [icon] - Icon identifier.
+   * @param {string} [text] - Text to display.
+   * @param {EntityCommand} [command] - Associated command.
+   * @throws AssertionError if invalid parameters are specified.
+   */
+  constructor(type, location, size, icon, text, command) {
+    assert(location instanceof Location, "location parameter must be of type Location");
+    assert(size === undefined || size instanceof Size, "size parameter must be of type Size");
+    assert(icon === undefined || typeof icon === "string", "icon parameter must be of type string");
+    assert(text === undefined || typeof text === "string", "text parameter must be of type string");
+    assert(
+      command === undefined || command instanceof EntityCommand,
+      "command parameter must be of type EntityCommand"
+    );
+    this.type = type;
+    this.location = location;
+    this.size = size;
+    this.icon = icon;
+    this.text = text;
+    this.command = command;
+  }
+}
+
+/**
+ * Create a text UI item.
+ * @param {string} text the text to show in the UI item.
+ * @param {number} x x-position, 0-based.
+ * @param {number} y y-position, 0-based.
+ * @param {string|EntityCommand} [cmd] associated command to the text item. A string parameter corresponds to
+ *            a simple command, whereas an ``EntityCommand`` allows to customize the
+ *            command for example with number of repeats.
+ * @param {Size} [size] item size, defaults to 1 x 1 if not specified.
+ * @return {UiItem} the created UiItem
+ * @throws AssertionError if invalid parameters are specified.
+ */
+function createUiText(text, x, y, cmd, size) {
+  if (typeof cmd === "string") {
+    cmd = new EntityCommand(cmd);
+  }
+  return new UiItem("text", new Location(x, y), size, undefined, text, cmd);
+}
+
+/**
+ * Create an icon UI item.
+ *
+ * The icon identifier consists of a prefix and a resource identifier,
+ * separated by `:`. Available prefixes:
+ *   - `uc:` - integrated icon font
+ *   - `custom:` - custom resource
+ * @param {string} icon the icon identifier of the icon to show in the UI item.
+ * @param {number} x x-position, 0-based.
+ * @param {number} y y-position, 0-based.
+ * @param {string|EntityCommand} [cmd] associated command to the text item. A string parameter corresponds to
+ *            a simple command, whereas an `EntityCommand` allows to customize the
+ *            command for example with number of repeats.
+ * @param {Size} [size] item size, defaults to 1 x 1 if not specified.
+ * @return {UiItem} the created UiItem
+ * @throws AssertionError if invalid parameters are specified.
+ */
+function createUiIcon(icon, x, y, cmd, size) {
+  if (typeof cmd === "string") {
+    cmd = new EntityCommand(cmd);
+  }
+  return new UiItem("icon", new Location(x, y), size, icon, undefined, cmd);
+}
+
+/**
+ * Definition of a complete user interface page.
+ */
+class UiPage {
+  /**
+   * Constructs a new UiPage.
+   *
+   * Default grid size is 4x6 if not specified.
+   * @param {string} pageId - Page identifier.
+   * @param {string} name - Page name.
+   * @param {Size} [grid] - Grid size.
+   * @param {Array<UiItem>} [items] - List of UI items on the page.
+   */
+  constructor(pageId, name, grid, items) {
+    this.page_id = pageId;
+    this.name = name;
+    this.grid = grid || new Size(4, 6);
+    this.items = items || [];
+  }
+
+  /**
+   * Append the given UiItem to the page items.
+   * @param {UiItem} item - The UI item to add.
+   */
+  add(item) {
+    this.items.push(item);
+  }
+}
+
+module.exports = {
+  BUTTONS,
+  EntityCommand,
+  DeviceButtonMapping,
+  createBtnMapping,
+  Size,
+  Location,
+  UiItem,
+  createUiText,
+  createUiIcon,
+  UiPage
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@
  * Convert an input text to a language object.
  *
  * An input text is either a simple string, which is mapped to the `en` language key, a Map containing language keys and
- * text values, or an Object with language key fields and text values.s
+ * text values, or an Object with language key fields and text values.
  * @param {string | Map<string, string> | Object<string, string> } text
  * @return {{[p: string]: string}|null}
  */

--- a/test/remote.test.js
+++ b/test/remote.test.js
@@ -1,0 +1,89 @@
+const test = require("ava");
+const { createSequenceCmd, createSendCmd } = require("../lib/entities/remote");
+const { EntityCommand } = require("../lib/entities/ui");
+
+const { AssertionError } = require("node:assert");
+
+test("createSequenceCmd with an undefined sequence throws an assert", (t) => {
+  t.throws(
+    () => {
+      createSequenceCmd(undefined);
+    },
+    { instanceOf: AssertionError }
+  );
+});
+
+test("createSequenceCmd with an empty sequence array throws an assert", (t) => {
+  t.throws(
+    () => {
+      createSequenceCmd([]);
+    },
+    { instanceOf: AssertionError }
+  );
+});
+
+test("createSequenceCmd without optional params doesn't include fields", (t) => {
+  const result = createSequenceCmd(["foo", "bar"]);
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd_sequence");
+  t.deepEqual(result.params, { sequence: ["foo", "bar"] });
+});
+
+test("createSequenceCmd with value 0 for delay and repeat returns values", (t) => {
+  const result = createSequenceCmd(["foo", "bar"], 0, 0);
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd_sequence");
+  t.deepEqual(result.params, { sequence: ["foo", "bar"], delay: 0, repeat: 0 });
+});
+
+test("createSequenceCmd with delay returns parameter field", (t) => {
+  const result = createSequenceCmd(["foo", "bar"], 100);
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd_sequence");
+  t.deepEqual(result.params, { sequence: ["foo", "bar"], delay: 100 });
+});
+
+test("createSequenceCmd with repeat returns parameter field", (t) => {
+  const result = createSequenceCmd(["foo", "bar"], undefined, 2);
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd_sequence");
+  t.deepEqual(result.params, { sequence: ["foo", "bar"], repeat: 2 });
+});
+
+test("createSendCmd with an undefined command throws an assert", (t) => {
+  t.throws(
+    () => {
+      createSendCmd(undefined);
+    },
+    { instanceOf: AssertionError }
+  );
+});
+
+test("createSendCmd with an empty command throws an assert", (t) => {
+  t.throws(
+    () => {
+      createSendCmd("");
+    },
+    { instanceOf: AssertionError }
+  );
+});
+
+test("createSendCmd without optional params doesn't include fields", (t) => {
+  const result = createSendCmd("foobar");
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd");
+  t.deepEqual(result.params, { command: "foobar" });
+});
+
+test("createSendCmd with optional params returns fields", (t) => {
+  const result = createSendCmd("foobar", 1, 2, 3);
+
+  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
+  t.is(result.cmd_id, "send_cmd");
+  t.deepEqual(result.params, { command: "foobar", delay: 1, repeat: 2, hold: 3 });
+});

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -1,0 +1,96 @@
+const test = require("ava");
+const { UiPage, Size, UiItem, createUiText, EntityCommand, createUiIcon } = require("../lib/entities/ui");
+
+test("Size sets default size if not specified", (t) => {
+  const result = new Size();
+
+  t.is(result.height, 1);
+  t.is(result.width, 1);
+});
+
+test("UiPage sets default grid size if not specified", (t) => {
+  const result = new UiPage("test", "Page");
+
+  t.deepEqual(JSON.parse(JSON.stringify(result)), {
+    page_id: "test",
+    name: "Page",
+    grid: { width: 4, height: 6 },
+    items: []
+  });
+});
+
+test("createUiText with a text command creates a simple command", (t) => {
+  const result = createUiText("test", 2, 3, "my_command");
+
+  t.true(result instanceof UiItem, "result must be a UiItem");
+
+  t.deepEqual(JSON.parse(JSON.stringify(result)), {
+    type: "text",
+    location: { x: 2, y: 3 },
+    text: "test",
+    command: { cmd_id: "my_command" }
+  });
+});
+
+test("createUiText with an EntityCommand creates a command with params", (t) => {
+  const result = createUiText(
+    "test",
+    2,
+    3,
+    new EntityCommand("my_command", { param1: "test", param2: 42, param3: ["foo", "bar"] })
+  );
+
+  t.true(result instanceof UiItem, "result must be a UiItem");
+
+  t.deepEqual(JSON.parse(JSON.stringify(result)), {
+    type: "text",
+    location: { x: 2, y: 3 },
+    text: "test",
+    command: {
+      cmd_id: "my_command",
+      params: {
+        param1: "test",
+        param2: 42,
+        param3: ["foo", "bar"]
+      }
+    }
+  });
+});
+
+test("createUiIcon with a text command creates a simple command", (t) => {
+  const result = createUiIcon("uc:star", 2, 3, "my_command");
+
+  t.true(result instanceof UiItem, "result must be a UiItem");
+
+  t.deepEqual(JSON.parse(JSON.stringify(result)), {
+    type: "icon",
+    location: { x: 2, y: 3 },
+    icon: "uc:star",
+    command: { cmd_id: "my_command" }
+  });
+});
+
+test("createUiIcon with an EntityCommand creates a command with params", (t) => {
+  const result = createUiIcon(
+    "uc:star",
+    2,
+    3,
+    new EntityCommand("my_command", { param1: "test", param2: 42, param3: ["foo", "bar"] })
+  );
+
+  t.true(result instanceof UiItem, "result must be a UiItem");
+
+  t.deepEqual(JSON.parse(JSON.stringify(result)), {
+    type: "icon",
+    location: { x: 2, y: 3 },
+    icon: "uc:star",
+    command: {
+      cmd_id: "my_command",
+      params: {
+        param1: "test",
+        param2: 42,
+        param3: ["foo", "bar"]
+      }
+    }
+  });
+});


### PR DESCRIPTION
Add remote-entity and helper functions to create button mappings and user interfaces definitions.
The functionality follows closely the Python integration wrapper library.

Other changes:
- clean-up of Entity constructor, default values and JSDoc.
- allow to pass an Object and not only a Map for the changed attributes in `Entities.updateEntityAttributes`

Closes #33