### PR TITLE
refactor!: use named parameters in entity constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Breaking changes
+- All entity class constructors have changed: use named parameters for all optional arguments. 
+
 ### Added
 - Remote-entity and UI definitions.
 - Setup-flow and remote examples.

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -86,15 +86,17 @@ const entity = new uc.Entities.MediaPlayer(
   entityId,
   // name of the entity
   entityName,
-  // define features in an array. Use the pre-defined object to choose features from
-  [uc.Entities.MediaPlayer.FEATURES.ON_OFF, uc.Entities.MediaPlayer.FEATURES.VOLUME],
-  // define default attributes for the entity. Use the pre-defined object to choose attributes from
-  new Map([
-    [uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF],
-    [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME, 0]
-  ])
+  {
+    // define features in an array. Use the pre-defined object to choose features from
+    features: [uc.Entities.MediaPlayer.FEATURES.ON_OFF, uc.Entities.MediaPlayer.FEATURES.VOLUME],
+    // define default attributes for the entity. Use the pre-defined object to choose attributes from
+    attributes: new Map([
+      [uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF],
+      [uc.Entities.MediaPlayer.ATTRIBUTES.VOLUME, 0]
+    ]),
+    cmdHandler
+  }
 );
-entity.setCmdHandler(cmdHandler);
 
 // 2. add available entity to the core
 uc.availableEntities.addEntity(entity);

--- a/examples/setup-flow/setup_flow.js
+++ b/examples/setup-flow/setup_flow.js
@@ -53,7 +53,7 @@ async function handleDriverSetup(msg) {
   // please note that all values are returned as strings!
   if (!("expert" in msg.setupData) || msg.setupData.expert !== "true") {
     // add a single button as default action
-    const button = new uc.Entities.Button("button", "Button", "test lab", cmdHandler);
+    const button = new uc.Entities.Button("button", "Button", { cmdHandler });
     uc.availableEntities.addEntity(button);
     return new uc.setup.SetupComplete();
   }
@@ -103,9 +103,7 @@ async function handleUserDataResponse(msg) {
   // values from all screens are returned: check in reverse order
   if ("step2.count" in msg.inputValues) {
     for (let x = 0; x < parseInt(msg.inputValues["step2.count"]); x++) {
-      const button = new uc.Entities.Button(`button${x}`, `Button ${x + 1}`);
-      button.setCmdHandler(cmdHandler);
-      uc.availableEntities.addEntity(button);
+      uc.availableEntities.addEntity(new uc.Entities.Button(`button${x}`, `Button ${x + 1}`, { cmdHandler }));
     }
 
     return new uc.setup.SetupComplete();

--- a/examples/simulated-light/light.js
+++ b/examples/simulated-light/light.js
@@ -139,29 +139,28 @@ const name = new Map([
   ["de", "Mein Lieblingslicht"],
   ["en", "My favorite light"]
 ]);
-const lightEntity = new uc.Entities.Light(
-  "my_unique_light_id",
-  name,
-  [uc.Entities.Light.FEATURES.ON_OFF, uc.Entities.Light.FEATURES.DIM],
-  new Map([
+const lightEntity = new uc.Entities.Light("my_unique_light_id", name, {
+  features: [uc.Entities.Light.FEATURES.ON_OFF, uc.Entities.Light.FEATURES.DIM],
+  attributes: new Map([
     [uc.Entities.Light.ATTRIBUTES.STATE, uc.Entities.Light.STATES.OFF],
     [uc.Entities.Light.ATTRIBUTES.BRIGHTNESS, 0]
   ])
-);
+});
 lightEntity.setCmdHandler(lightCmdHandler);
 
 // add entity as available
 // this is important, so the core knows what entities are available
 uc.availableEntities.addEntity(lightEntity);
 
-const buttonEntity = new uc.Entities.Button("my_button", "Push the button!", "test lab", sharedCmdHandler);
+const buttonEntity = new uc.Entities.Button("my_button", "Push the button!", {
+  area: "test lab",
+  cmdHandler: sharedCmdHandler
+});
 uc.availableEntities.addEntity(buttonEntity);
 
 // add a media-player entity
-const mediaPlayerEntity = new uc.Entities.MediaPlayer(
-  "test_mediaplayer",
-  new Map([["en", "Foobar MediaPlayer"]]),
-  [
+const mediaPlayerEntity = new uc.Entities.MediaPlayer("test_mediaplayer", new Map([["en", "Foobar MediaPlayer"]]), {
+  features: [
     uc.Entities.MediaPlayer.FEATURES.ON_OFF,
     uc.Entities.MediaPlayer.FEATURES.DPAD,
     uc.Entities.MediaPlayer.FEATURES.HOME,
@@ -171,11 +170,11 @@ const mediaPlayerEntity = new uc.Entities.MediaPlayer(
     uc.Entities.MediaPlayer.FEATURES.COLOR_BUTTONS,
     uc.Entities.MediaPlayer.FEATURES.PLAY_PAUSE
   ],
-  new Map([
+  attributes: new Map([
     [uc.Entities.MediaPlayer.ATTRIBUTES.STATE, uc.Entities.MediaPlayer.STATES.OFF],
     [uc.Entities.MediaPlayer.ATTRIBUTES.SOURCE_LIST, ["Radio", "Streaming", "Favorite 1", "Favorite 2", "Favorite 3"]]
   ]),
-  uc.Entities.MediaPlayer.DEVICECLASSES.STREAMING_BOX
-);
+  deviceClass: uc.Entities.MediaPlayer.DEVICECLASSES.STREAMING_BOX
+});
 mediaPlayerEntity.setCmdHandler(sharedCmdHandler);
 uc.availableEntities.addEntity(mediaPlayerEntity);

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function log(message) {
 }
 
 class IntegrationAPI extends EventEmitter {
+  #configDirPath;
   #driverPath;
   #driverInfo;
   #state;
@@ -37,7 +38,7 @@ class IntegrationAPI extends EventEmitter {
     this.#driverPath = "driver.json";
 
     // directory to store configuration files
-    this.configDirPath = process.env.UC_CONFIG_HOME || process.env.HOME || "./";
+    this.#configDirPath = process.env.UC_CONFIG_HOME || process.env.HOME || "./";
 
     // set default state to connected
     this.#state = uc.DEVICE_STATES.DISCONNECTED;
@@ -166,6 +167,10 @@ class IntegrationAPI extends EventEmitter {
         this.#clients.delete(connection);
       });
     });
+  }
+
+  get configDirPath() {
+    return this.#configDirPath;
   }
 
   /**

--- a/lib/entities/button.js
+++ b/lib/entities/button.js
@@ -45,16 +45,23 @@ class Button extends Entity {
   /**
    * Constructs a new button entity.
    *
+   * - The one-and-only `press` feature is automatically added.
+   * - STATES.AVAILABLE is set if no entity-state is provided.
+   *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string} [params.state] Button state, one of {@link STATES}.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, area, cmdHandler = null) {
+  constructor(id, name, { state = STATES.AVAILABLE, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.BUTTON, {
       features: ["press"],
-      attributes: new Map([[ATTRIBUTES.STATE, STATES.AVAILABLE]]),
+      attributes: new Map([[ATTRIBUTES.STATE, state]]),
       area,
       cmdHandler
     });

--- a/lib/entities/climate.js
+++ b/lib/entities/climate.js
@@ -97,16 +97,19 @@ class Climate extends Entity {
    * Constructs a new climate entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string[]} [params.features] Entity features.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
+  constructor(id, name, { features, attributes, deviceClass, options, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.CLIMATE, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Climate entity created with id: ${this.id}`);

--- a/lib/entities/cover.js
+++ b/lib/entities/cover.js
@@ -96,16 +96,19 @@ class Cover extends Entity {
    * Constructs a new cover entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string[]} [params.features] Entity features.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
+  constructor(id, name, { features, attributes, deviceClass, options, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.COVER, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Cover entity created with id: ${this.id}`);

--- a/lib/entities/entities.js
+++ b/lib/entities/entities.js
@@ -35,7 +35,7 @@ class Entities extends EventEmitter {
 
   getEntity(id) {
     if (!this.#storage[id]) {
-      console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
+      console.log(`ENTITIES(${this.id}): Entity does not exist: ${id}`);
       return null;
     }
 
@@ -55,7 +55,7 @@ class Entities extends EventEmitter {
 
   removeEntity(id) {
     if (!this.#storage[id]) {
-      console.log(`ENTITIES(${this.id}): Entity does not exists: ${id}`);
+      console.log(`ENTITIES(${this.id}): Entity does not exist: ${id}`);
       return false;
     }
 
@@ -69,7 +69,7 @@ class Entities extends EventEmitter {
    * Update or merge the provided attributes into an entity.
    *
    * @param {string} id The entity_id
-   * @param {Map<string,string>|Object<string,string>} attributes The attributes to merge into the entity's attributes
+   * @param {Map<string,*>|Object<string,*>} attributes The attributes to merge into the entity's attributes
    * @returns {boolean} false if entity doesn't exist, true if attributes were merged.
    */
   updateEntityAttributes(id, attributes) {

--- a/lib/entities/entity.js
+++ b/lib/entities/entity.js
@@ -37,12 +37,12 @@ class Entity {
    * @param {string|Map} name The human-readable name of the entity.
    *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
    * @param {string} entityType One of defined [Entity.TYPES]{@link TYPES}.
-   * @param {Object} params entity parameters
-   * @param {string[]} [params.features=[]] Optional entity features.
-   * @param {Map | null} params.attributes Optional entity attribute Map holding the current state.
-   * @param {string} [params.deviceClass] Optional device class.
+   * @param {Object} params Entity parameters.
+   * @param {string[]} [params.features=[]] Entity features.
+   * @param {Map<string,*> | Object<string,*> | null} [params.attributes=null] Entity attributes holding the current state.
+   * @param {string} [params.deviceClass] Device class.
    * @param {object | null} [params.options=null] Further options. See entity documentation.
-   * @param {string} [params.area] Optional area or room.
+   * @param {string} [params.area] Area or room.
    * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
    *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
@@ -61,8 +61,17 @@ class Entity {
     this.device_id = null; // not yet supported
     assert(features instanceof Array, "Entity parameter features must be an Array");
     this.features = features;
-    assert(attributes === null || attributes instanceof Map, "Entity parameter attributes must be a Map");
-    this.attributes = attributes ? Object.fromEntries(attributes) : null;
+    assert(
+      attributes === null || attributes instanceof Map || attributes instanceof Object,
+      "Entity parameter attributes must be a Map or Object"
+    );
+    if (attributes === null) {
+      this.attributes = null;
+    } else if (attributes instanceof Map) {
+      this.attributes = Object.fromEntries(attributes);
+    } else if (attributes instanceof Object) {
+      this.attributes = { ...attributes };
+    }
     assert(
       deviceClass === undefined || typeof deviceClass === "string",
       "Entity parameter deviceClass must be a string"

--- a/lib/entities/light.js
+++ b/lib/entities/light.js
@@ -80,16 +80,19 @@ class Light extends Entity {
    * Constructs a new light entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string[]} [params.features] Entity features.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
+  constructor(id, name, { features, attributes, deviceClass, options, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.LIGHT, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Light entity created with id: ${this.id}`);

--- a/lib/entities/media_player.js
+++ b/lib/entities/media_player.js
@@ -217,16 +217,19 @@ class MediaPlayer extends Entity {
    * Constructs a new media-player entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string[]} [params.features] Entity features.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
+  constructor(id, name, { features, attributes, deviceClass, options, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.MEDIA_PLAYER, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`MediaPlayer entity created with id: ${this.id}`);

--- a/lib/entities/remote.js
+++ b/lib/entities/remote.js
@@ -124,22 +124,18 @@ class Remote extends Entity {
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
    * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
    *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {Object} [params] optional named parameters
-   * @param {Array<string>} params.features - remote features.
-   * @param {Map} params.attributes remote attributes.
+   * @param {Object} [params] Entity parameters.
+   * @param {Array<string>} [params.features] Remote features.
+   * @param {Map|Object} [params.attributes] Remote attributes.
    * @param {Array<string>} [params.simpleCommands] Optional list of supported remote command identifiers.
    * @param {Array<DeviceButtonMapping|Object<string, *>>} [params.buttonMapping] Optional command mapping of physical buttons.
    * @param {Array<UiPage|Object<string, *>>} [params.uiPages] Optional user interface page definitions.
-   * @param {string} [params.area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} params.cmdHandler
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
    *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(
-    id,
-    name,
-    { features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler = null } = {}
-  ) {
+  constructor(id, name, { features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler } = {}) {
     const options = {};
     if (simpleCommands) {
       options[OPTIONS.SIMPLE_COMMANDS] = simpleCommands;

--- a/lib/entities/sensor.js
+++ b/lib/entities/sensor.js
@@ -83,14 +83,16 @@ class Sensor extends Entity {
    * Constructs a new sensor entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, attributes, deviceClass, options = null, area) {
+  constructor(id, name, { attributes, deviceClass, options, area } = {}) {
     super(id, name, Entity.TYPES.SENSOR, { attributes, deviceClass, options, area });
 
     console.debug(`Sensor entity created with id: ${this.id}`);

--- a/lib/entities/switch.js
+++ b/lib/entities/switch.js
@@ -77,16 +77,19 @@ class Switch extends Entity {
    * Constructs a new switch entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity. Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
-   * @param {string[]} features Optional entity features.
-   * @param {Map} attributes Optional entity attribute Map holding the current state.
-   * @param {string} [deviceClass] Optional device class.
-   * @param {object} options Further options. See entity documentation.
-   * @param {string} [area] Optional area or room.
-   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} cmdHandler Callback handler for entity commands, returning a {@link STATUS_CODES}
+   * @param {string | Map<string, string> | Object<string, string> } name The human-readable name of the entity.
+   *        Either a string, which will be mapped to english, or a Map / Object containing multiple language strings.
+   * @param {Object} [params] Entity parameters.
+   * @param {string[]} [params.features] Entity features.
+   * @param {Map|Object} [params.attributes] Entity attributes holding the current states.
+   * @param {string} [params.deviceClass] Device class.
+   * @param {object} [params.options] Further options. See entity documentation.
+   * @param {string} [params.area] Area or room.
+   * @param {?function(Entity, string, Object.<string, *> | undefined):Promise<string>} [params.cmdHandler]
+   *        Callback handler for entity commands, returning a {@link STATUS_CODES}
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id, name, features, attributes, deviceClass, options = null, area, cmdHandler = null) {
+  constructor(id, name, { features, attributes, deviceClass, options, area, cmdHandler } = {}) {
     super(id, name, Entity.TYPES.SWITCH, { features, attributes, deviceClass, options, area, cmdHandler });
 
     console.debug(`Switch entity created with id: ${this.id}`);

--- a/test/button.test.js
+++ b/test/button.test.js
@@ -1,0 +1,35 @@
+const test = require("ava");
+const { Button } = require("../lib/entities/entities");
+
+test("Button constructor without parameter object creates default Button class", (t) => {
+  const entity = new Button("test", "Test Button");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Button" });
+  t.is(entity.entity_type, "button");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["press"]);
+  t.deepEqual(entity.attributes, { state: "AVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Button constructor with parameter object", (t) => {
+  const entity = new Button("test", "Test Button", {
+    state: Button.STATES.UNAVAILABLE,
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Button" });
+  t.is(entity.entity_type, "button");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["press"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});

--- a/test/climate.test.js
+++ b/test/climate.test.js
@@ -1,0 +1,50 @@
+const test = require("ava");
+const { Climate } = require("../lib/entities/entities");
+
+test("Climate constructor without parameter object creates default Climate class", (t) => {
+  const entity = new Climate("test", "Test Climate");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Climate" });
+  t.is(entity.entity_type, "climate");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Climate constructor with parameter object", (t) => {
+  const options = {};
+  options[Climate.OPTIONS.TEMPERATURE_UNIT] = "C";
+  const entity = new Climate("test", "Test Climate", {
+    features: [Climate.FEATURES.COOL],
+    attributes: new Map([[Climate.ATTRIBUTES.STATE, Climate.STATES.UNAVAILABLE]]),
+    options,
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Climate" });
+  t.is(entity.entity_type, "climate");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["cool"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.deepEqual(entity.options, { temperature_unit: "C" });
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Climate constructor with Object attributes", (t) => {
+  const entity = new Climate("test", "Test Climate", {
+    attributes: { state: "COOL" }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Climate" });
+  t.is(entity.entity_type, "climate");
+  t.deepEqual(entity.attributes, { state: "COOL" });
+});

--- a/test/cover.test.js
+++ b/test/cover.test.js
@@ -1,0 +1,48 @@
+const test = require("ava");
+const { Cover } = require("../lib/entities/entities");
+
+test("Cover constructor without parameter object creates default Cover class", (t) => {
+  const entity = new Cover("test", "Test Cover");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Cover" });
+  t.is(entity.entity_type, "cover");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Cover constructor with parameter object", (t) => {
+  const entity = new Cover("test", "Test Cover", {
+    features: [Cover.FEATURES.TILT],
+    attributes: new Map([[Cover.ATTRIBUTES.STATE, Cover.STATES.UNAVAILABLE]]),
+    options: {},
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Cover" });
+  t.is(entity.entity_type, "cover");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["tilt"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.deepEqual(entity.options, {});
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Cover constructor with Object attributes", (t) => {
+  const entity = new Cover("test", "Test Cover", {
+    attributes: { position: 50 }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Cover" });
+  t.is(entity.entity_type, "cover");
+  t.deepEqual(entity.attributes, { position: 50 });
+});

--- a/test/light.test.js
+++ b/test/light.test.js
@@ -1,0 +1,48 @@
+const test = require("ava");
+const { Light } = require("../lib/entities/entities");
+
+test("Light constructor without parameter object creates default Light class", (t) => {
+  const entity = new Light("test", "Test Light");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Light" });
+  t.is(entity.entity_type, "light");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Light constructor with parameter object", (t) => {
+  const entity = new Light("test", "Test Light", {
+    features: [Light.FEATURES.COLOR_TEMPERATURE],
+    attributes: new Map([[Light.ATTRIBUTES.STATE, Light.STATES.UNAVAILABLE]]),
+    options: {},
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Light" });
+  t.is(entity.entity_type, "light");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["color_temperature"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.deepEqual(entity.options, {});
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Light constructor with Object attributes", (t) => {
+  const entity = new Light("test", "Test Light", {
+    attributes: { brightness: 33 }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Light" });
+  t.is(entity.entity_type, "light");
+  t.deepEqual(entity.attributes, { brightness: 33 });
+});

--- a/test/media_player.test.js
+++ b/test/media_player.test.js
@@ -1,0 +1,53 @@
+const test = require("ava");
+const { MediaPlayer } = require("../lib/entities/entities");
+
+test("MediaPlayer constructor without parameter object creates default MediaPlayer class", (t) => {
+  const entity = new MediaPlayer("test", "Test MediaPlayer");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test MediaPlayer" });
+  t.is(entity.entity_type, "media_player");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("MediaPlayer constructor with parameter object", (t) => {
+  const options = {};
+  options[MediaPlayer.OPTIONS.VOLUME_STEPS] = 10;
+  const entity = new MediaPlayer("test", "Test MediaPlayer", {
+    features: [MediaPlayer.FEATURES.MENU],
+    attributes: new Map([
+      [MediaPlayer.ATTRIBUTES.STATE, MediaPlayer.STATES.UNAVAILABLE],
+      [MediaPlayer.ATTRIBUTES.VOLUME, 22]
+    ]),
+    options,
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test MediaPlayer" });
+  t.is(entity.entity_type, "media_player");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["menu"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE", volume: 22 });
+  t.is(entity.device_class, undefined);
+  t.deepEqual(entity.options, { volume_steps: 10 });
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("MediaPlayer constructor with Object attributes", (t) => {
+  const entity = new MediaPlayer("test", "Test MediaPlayer", {
+    attributes: { shuffle: false, muted: false, volume: 25 }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test MediaPlayer" });
+  t.is(entity.entity_type, "media_player");
+  t.deepEqual(entity.attributes, { shuffle: false, muted: false, volume: 25 });
+});

--- a/test/remote.test.js
+++ b/test/remote.test.js
@@ -123,3 +123,14 @@ test("Remote constructor with parameter object", (t) => {
   t.is(remote.area, "Test lab");
   t.is(remote.hasCmdHandler, false);
 });
+
+test("Remote constructor with Object attributes", (t) => {
+  const entity = new Remote("test", "Test Remote", {
+    attributes: { state: Remote.STATES.UNAVAILABLE }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Remote" });
+  t.is(entity.entity_type, "remote");
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+});

--- a/test/sensor.test.js
+++ b/test/sensor.test.js
@@ -1,0 +1,50 @@
+const test = require("ava");
+const { Sensor } = require("../lib/entities/entities");
+
+test("Sensor constructor without parameter object creates default Sensor class", (t) => {
+  const entity = new Sensor("test", "Test Sensor");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Sensor" });
+  t.is(entity.entity_type, "sensor");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Sensor constructor with parameter object", (t) => {
+  const options = {};
+  options[Sensor.OPTIONS.MAX_VALUE] = 42;
+  const entity = new Sensor("test", "Test Sensor", {
+    attributes: new Map([[Sensor.ATTRIBUTES.STATE, Sensor.STATES.UNAVAILABLE]]),
+    options,
+    deviceClass: Sensor.DEVICECLASSES.ENERGY,
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Sensor" });
+  t.is(entity.entity_type, "sensor");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, "energy");
+  t.deepEqual(entity.options, { max_value: 42 });
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Sensor constructor with Object attributes", (t) => {
+  const entity = new Sensor("test", "Test Sensor", {
+    attributes: { state: Sensor.STATES.ON, value: 100, unit: "%" }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Sensor" });
+  t.is(entity.entity_type, "sensor");
+  t.deepEqual(entity.attributes, { state: "ON", value: 100, unit: "%" });
+});

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -1,0 +1,50 @@
+const test = require("ava");
+const { Switch } = require("../lib/entities/entities");
+
+test("Switch constructor without parameter object creates default Switch class", (t) => {
+  const entity = new Switch("test", "Test Switch");
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Switch" });
+  t.is(entity.entity_type, "switch");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, []);
+  t.is(entity.attributes, null);
+  t.is(entity.device_class, undefined);
+  t.is(entity.options, null);
+  t.is(entity.area, undefined);
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Switch constructor with parameter object", (t) => {
+  const options = {};
+  options[Switch.OPTIONS.READABLE] = true;
+  const entity = new Switch("test", "Test Switch", {
+    features: [Switch.FEATURES.TOGGLE],
+    attributes: new Map([[Switch.ATTRIBUTES.STATE, Switch.STATES.UNAVAILABLE]]),
+    options,
+    area: "Test lab"
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Switch" });
+  t.is(entity.entity_type, "switch");
+  t.is(entity.device_id, null);
+  t.deepEqual(entity.features, ["toggle"]);
+  t.deepEqual(entity.attributes, { state: "UNAVAILABLE" });
+  t.is(entity.device_class, undefined);
+  t.deepEqual(entity.options, { readable: true });
+  t.is(entity.area, "Test lab");
+  t.is(entity.hasCmdHandler, false);
+});
+
+test("Switch constructor with Object attributes", (t) => {
+  const entity = new Switch("test", "Test Switch", {
+    attributes: { state: Switch.STATES.OFF }
+  });
+
+  t.is(entity.id, "test");
+  t.deepEqual(entity.name, { en: "Test Switch" });
+  t.is(entity.entity_type, "switch");
+  t.deepEqual(entity.attributes, { state: "OFF" });
+});


### PR DESCRIPTION
- Get rid of ugly constructors requiring all parameters.
- Also allow an Object for entity attributes and not just a Map.
- Add some unit tests for entity creation.

BREAKING CHANGE: all entity creation code needs to be updated.