### PR TITLE
Simplify exports, fix regressions, add missing types

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -3,7 +3,7 @@
 # More details at https://github.com/eslint/eslint
 # and https://eslint.org
 
-name: Check Node.js code formatting
+name: Check code formatting and types
 
 on:
   push:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   eslint:
-    name: Run prettier & eslint scanning
+    name: Run prettier, eslint, tsc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,5 +42,8 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Run configured Prettier & ESLint
-        run: npm run lint
+      - name: Check with Prettier & ESLint
+        run: npm run code-check
+
+      - name: Type check
+        run: tsc

--- a/examples/minimum-required.js
+++ b/examples/minimum-required.js
@@ -1,32 +1,36 @@
 // use integration library in a client project:
-// import uc from "@unfoldedcircle/integration-api";
-import uc from "../index.js";
+// import * as uc from "@unfoldedcircle/integration-api";
+import * as uc from "../dist/index.js";
+import { MediaPlayerAttributes, MediaPlayerFeatures, MediaPlayerStates } from "../dist/index.js";
 
-uc.init("driver.json");
+const driver = new uc.IntegrationAPI();
+
+driver.init("driver.json");
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // Handling events
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-uc.on(uc.Events.Connect, async () => {
+driver.on(uc.Events.Connect, async () => {
   // act on when the core connects to the integration
   // for example: start polling your devices
-  await uc.setDeviceState(uc.DeviceStates.Connected);
+  await driver.setDeviceState(uc.DeviceStates.Connected);
 });
 
-uc.on(uc.Events.Disconnect, async () => {
+driver.on(uc.Events.Disconnect, async () => {
   // act on when the core disconnects from the integration
   // for example: stop polling your devices
-  await uc.setDeviceState(uc.DeviceStates.Disconnected);
+  await driver.setDeviceState(uc.DeviceStates.Disconnected);
 });
 
-uc.on(uc.Events.EnterStandby, async () => {
+driver.on(uc.Events.EnterStandby, async () => {
   // act on when the remote goes to standby
 });
 
-uc.on(uc.Events.ExitStandby, async () => {
+driver.on(uc.Events.ExitStandby, async () => {
   // act on when the remote leaves standby
 });
 
-uc.on(uc.Events.SubscribeEntities, async () => {
+driver.on(uc.Events.SubscribeEntities, async () => {
   // The integration will configure entities and subscribe for entity update events.
   // The UC library automatically adds the subscribed entities
   // from the available to the configured pool.
@@ -34,7 +38,7 @@ uc.on(uc.Events.SubscribeEntities, async () => {
   // ...
 });
 
-uc.on(uc.Events.UnsubscribeEntities, async () => {
+driver.on(uc.Events.UnsubscribeEntities, async () => {
   // When the integration unsubscribed from certain entity updates,
   // the UC library automatically removes the unsubscribed entities
   // from the configured pool.
@@ -52,7 +56,7 @@ uc.on(uc.Events.UnsubscribeEntities, async () => {
  * @param {Entity} entity button entity
  * @param {string} cmdId command
  * @param {Object<string, *>} [params] optional command parameters
- * @return {Promise<uc.StatusCodes>} status of the command
+ * @return StatusCodes of the command
  */
 
 const cmdHandler = async function (entity, cmdId, params) {
@@ -79,25 +83,25 @@ const entityId = "unique-id-inside-integration";
 // The entity name can either be string (which will be mapped to english), or a Map with multiple language entries.
 const entityName = "My entity";
 
-const entity = new uc.entities.MediaPlayer(
-  // entity id has to be unique, you can provide it or use uc.entities.generateId()
+const entity = new uc.MediaPlayer(
+  // entity id has to be unique, you can provide it or use driver.entities.generateId()
   entityId,
   // name of the entity
   entityName,
   {
     // define features in an array. Use the pre-defined object to choose features from
-    features: [uc.entities.MediaPlayer.Features.OnOff, uc.entities.MediaPlayer.Features.Volume],
+    features: [MediaPlayerFeatures.OnOff, MediaPlayerFeatures.Volume],
     // define default attributes for the entity. Use the pre-defined object to choose attributes from
     attributes: {
-      [uc.entities.MediaPlayer.Attributes.State]: uc.entities.MediaPlayer.States.Off,
-      [uc.entities.MediaPlayer.Attributes.Volume]: 0
+      [MediaPlayerAttributes.State]: MediaPlayerStates.Off,
+      [MediaPlayerAttributes.Volume]: 0
     },
     cmdHandler
   }
 );
 
 // 2. add available entity to the core
-uc.addAvailableEntity(entity);
+driver.addAvailableEntity(entity);
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 // Updating entities
@@ -105,15 +109,15 @@ uc.addAvailableEntity(entity);
 // when your integration driver needs to update an entity based on a device change
 // keys and values are attribute key and value pairs
 const attributes = {};
-uc.updateEntityAttributes(entityId, attributes);
+driver.updateEntityAttributes(entityId, attributes);
 
 // for example to update a state fo a media player:
-uc.updateEntityAttributes(entityId, {
-  [uc.entities.MediaPlayer.Attributes.State]: uc.entities.MediaPlayer.States.Playing
+driver.updateEntityAttributes(entityId, {
+  [MediaPlayerAttributes.State]: MediaPlayerStates.Playing
 });
 
 // or multiple attributes at the same time
-uc.updateEntityAttributes(entityId, {
-  [uc.entities.MediaPlayer.Attributes.State]: uc.entities.MediaPlayer.States.Playing,
-  [uc.entities.MediaPlayer.Attributes.MediaArtist]: "Massive Attack"
+driver.updateEntityAttributes(entityId, {
+  [MediaPlayerAttributes.State]: MediaPlayerStates.Playing,
+  [MediaPlayerAttributes.MediaArtist]: "Massive Attack"
 });

--- a/examples/remote/remote.js
+++ b/examples/remote/remote.js
@@ -1,8 +1,11 @@
 // use integration library in a client project:
-// import uc from "@unfoldedcircle/integration-api";
-import uc from "../../dist/index.js";
+// import * as uc from "@unfoldedcircle/integration-api";
+import * as uc from "../../dist/index.js";
+import { Remote, RemoteStates, RemoteCommands, RemoteAttributes, RemoteFeatures } from "../../dist/index.js";
 
 import fs from "fs";
+
+const driver = new uc.IntegrationAPI();
 
 // Simple commands supported by this example remote entity
 const supportedCommands = [
@@ -40,19 +43,16 @@ const cmdHandler = async function (entity, cmdId, params = {}) {
 
   let state = null;
   switch (cmdId) {
-    case uc.entities.Remote.Commands.On:
-      state = uc.entities.Remote.States.On;
+    case RemoteCommands.On:
+      state = RemoteStates.On;
       break;
-    case uc.entities.Remote.Commands.Off:
-      state = uc.entities.Remote.States.Off;
+    case RemoteCommands.Off:
+      state = RemoteStates.Off;
       break;
-    case uc.entities.Remote.Commands.Toggle:
-      state =
-        entity.attributes?.[uc.entities.Remote.Attributes.State] === uc.entities.Remote.States.Off
-          ? uc.entities.Remote.States.On
-          : uc.entities.Remote.States.Off;
+    case RemoteCommands.Toggle:
+      state = entity.attributes?.[RemoteAttributes.State] === RemoteStates.Off ? RemoteStates.On : RemoteStates.Off;
       break;
-    case uc.entities.Remote.Commands.SendCmd: {
+    case RemoteCommands.SendCmd: {
       const command = params.command ?? "";
       if (!supportedCommands.includes(command)) {
         console.error(`Unknown command: ${command}`);
@@ -64,7 +64,7 @@ const cmdHandler = async function (entity, cmdId, params = {}) {
       console.log(`Command: ${command} (repeat=${repeat}, delay=${delay}, hold=${hold})`);
       break;
     }
-    case uc.entities.Remote.Commands.SendCmdSequence: {
+    case RemoteCommands.SendCmdSequence: {
       const sequence = params.sequence;
       const seqRepeat = params.repeat || 1;
       const seqDelay = params.delay || 0;
@@ -78,21 +78,21 @@ const cmdHandler = async function (entity, cmdId, params = {}) {
 
   if (state) {
     const newState = {
-      [uc.entities.Remote.Attributes.State]: state
+      [RemoteAttributes.State]: state
     };
-    uc.getConfiguredEntities().updateEntityAttributes(entity.id, newState);
+    driver.getConfiguredEntities().updateEntityAttributes(entity.id, newState);
   }
 
   return uc.StatusCodes.Ok;
 };
 
 // Event listener for connection event
-uc.on(uc.Events.Connect, async () => {
-  await uc.setDeviceState(uc.DeviceStates.Connected);
+driver.on(uc.Events.Connect, async () => {
+  await driver.setDeviceState(uc.DeviceStates.Connected);
 });
 
-uc.on(uc.Events.Disconnect, async () => {
-  await uc.setDeviceState(uc.DeviceStates.Disconnected);
+driver.on(uc.Events.Disconnect, async () => {
+  await driver.setDeviceState(uc.DeviceStates.Disconnected);
 });
 
 // Create button mappings
@@ -105,10 +105,10 @@ const createButtonMappings = () => {
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadDown, "CURSOR_DOWN"),
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadLeft, "CURSOR_LEFT"),
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadRight, "CURSOR_RIGHT"),
-    uc.ui.createBtnMapping(uc.ui.Buttons.DpadMiddle, uc.entities.Remote.createSendCmd("CONTEXT_MENU", { hold: 100 })),
+    uc.ui.createBtnMapping(uc.ui.Buttons.DpadMiddle, Remote.createSendCmd("CONTEXT_MENU", { hold: 100 })),
     uc.ui.createBtnMapping(
       uc.ui.Buttons.Blue,
-      uc.entities.Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 })
+      Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 })
     ),
     uc.ui.createBtnMapping(uc.ui.Buttons.Power, new uc.ui.EntityCommand("remote.toggle"))
   ];
@@ -133,7 +133,7 @@ const createUi = () => {
       "Pump up the volume!",
       0,
       0,
-      uc.entities.Remote.createSendCmd("VOLUME_UP", { repeat: 5 }),
+      Remote.createSendCmd("VOLUME_UP", { repeat: 5 }),
       new uc.ui.Size(4, 2)
     )
   );
@@ -142,7 +142,7 @@ const createUi = () => {
       "Test sequence",
       0,
       4,
-      uc.entities.Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 }),
+      Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 }),
       new uc.ui.Size(4, 1)
     )
   );
@@ -154,14 +154,14 @@ const createUi = () => {
 
 // -- startup driver
 
-const entity = new uc.entities.Remote("remote1", "Demo remote", {
-  features: [uc.entities.Remote.Features.OnOff, uc.entities.Remote.Features.Toggle],
-  attributes: { [uc.entities.Remote.Attributes.State]: uc.entities.Remote.States.Off },
+const entity = new Remote("remote1", "Demo remote", {
+  features: [RemoteFeatures.OnOff, RemoteFeatures.Toggle],
+  attributes: { [RemoteAttributes.State]: RemoteStates.Off },
   simpleCommands: supportedCommands,
   buttonMapping: createButtonMappings(),
   uiPages: createUi(),
   cmdHandler
 });
 
-uc.addAvailableEntity(entity);
-uc.init("remote.json");
+driver.addAvailableEntity(entity);
+driver.init("remote.json");

--- a/examples/remote/remote.js
+++ b/examples/remote/remote.js
@@ -105,10 +105,10 @@ const createButtonMappings = () => {
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadDown, "CURSOR_DOWN"),
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadLeft, "CURSOR_LEFT"),
     uc.ui.createBtnMapping(uc.ui.Buttons.DpadRight, "CURSOR_RIGHT"),
-    uc.ui.createBtnMapping(uc.ui.Buttons.DpadMiddle, Remote.createSendCmd("CONTEXT_MENU", { hold: 100 })),
+    uc.ui.createBtnMapping(uc.ui.Buttons.DpadMiddle, uc.createRemoteSendCmd("CONTEXT_MENU", { hold: 100 })),
     uc.ui.createBtnMapping(
       uc.ui.Buttons.Blue,
-      Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 })
+      uc.createRemoteSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 })
     ),
     uc.ui.createBtnMapping(uc.ui.Buttons.Power, new uc.ui.EntityCommand("remote.toggle"))
   ];
@@ -133,7 +133,7 @@ const createUi = () => {
       "Pump up the volume!",
       0,
       0,
-      Remote.createSendCmd("VOLUME_UP", { repeat: 5 }),
+      uc.createRemoteSendCmd("VOLUME_UP", { repeat: 5 }),
       new uc.ui.Size(4, 2)
     )
   );
@@ -142,7 +142,7 @@ const createUi = () => {
       "Test sequence",
       0,
       4,
-      Remote.createSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 }),
+      uc.createRemoteSequenceCmd(["CURSOR_UP", "CURSOR_RIGHT", "CURSOR_DOWN", "CURSOR_LEFT"], { delay: 200 }),
       new uc.ui.Size(4, 1)
     )
   );

--- a/examples/setup-flow/setup_flow.js
+++ b/examples/setup-flow/setup_flow.js
@@ -3,23 +3,40 @@
  */
 
 // use integration library in a client project:
-// import uc from "@unfoldedcircle/integration-api";
-import uc from "../../dist/index.js";
+// import * as uc from "@unfoldedcircle/integration-api";
+import * as uc from "../../dist/index.js";
+
+const driver = new uc.IntegrationAPI();
+
+/**
+ * Push button command handler.
+ *
+ * Called by the integration-API if a command is sent to a configured button-entity.
+ *
+ * @param {Entity} entity button entity
+ * @param {string} cmdId command
+ * @param {Object<string, *>} [_params] optional command parameters (not used for buttons)
+ * @return status of the command
+ */
+const cmdHandler = async function (entity, cmdId, _params) {
+  console.log("Got %s command request: %s", entity.id, cmdId);
+  return uc.StatusCodes.Ok;
+};
 
 /**
  * Dispatch driver setup requests to corresponding handlers.
  *
  * Either start the setup process or handle the provided user input data.
- * @param {uc.setup.SetupDriver} msg the setup driver request object, either DriverSetupRequest,
+ * @param {uc.SetupDriver} msg the setup driver request object, either DriverSetupRequest,
  *                 UserDataResponse or UserConfirmationResponse
  * @return the SetupAction on how to continue
  */
 
 const driverSetupHandler = async function (msg) {
-  if (msg instanceof uc.setup.DriverSetupRequest) {
+  if (msg instanceof uc.DriverSetupRequest) {
     return await handleDriverSetup(msg);
   }
-  if (msg instanceof uc.setup.UserDataResponse) {
+  if (msg instanceof uc.UserDataResponse) {
     return await handleUserDataResponse(msg);
   }
 
@@ -28,14 +45,14 @@ const driverSetupHandler = async function (msg) {
   //     return handle_user_confirmation(msg)
   // }
 
-  return new uc.setup.SetupError();
+  return new uc.SetupError();
 };
 
 /**
  * Start driver setup.
  *
  * Initiated by the UC Remote to set up the driver.
- * @param {uc.setup.DriverSetupRequest} msg value(s) of input fields in the first setup screen.
+ * @param {uc.DriverSetupRequest} msg value(s) of input fields in the first setup screen.
  * @return the SetupAction on how to continue
  */
 async function handleDriverSetup(msg) {
@@ -46,16 +63,16 @@ async function handleDriverSetup(msg) {
 
   // For our demo we simply clear everything!
   // A real driver might have to handle this differently
-  uc.clearAvailableEntities();
-  uc.clearConfiguredEntities();
+  driver.clearAvailableEntities();
+  driver.clearConfiguredEntities();
 
   // check if user selected the expert option in the initial setup screen
   // please note that all values are returned as strings!
   if (!("expert" in msg.setupData) || msg.setupData.expert !== "true") {
     // add a single button as default action
-    const button = new uc.entities.Button("button", "Button", { cmdHandler });
-    uc.addAvailableEntity(button);
-    return new uc.setup.SetupComplete();
+    const button = new uc.Button("button", "Button", { cmdHandler });
+    driver.addAvailableEntity(button);
+    return new uc.SetupComplete();
   }
 
   // Dropdown selections are usually set dynamically, e.g. with found devices etc.
@@ -65,7 +82,7 @@ async function handleDriverSetup(msg) {
     { id: "blue", label: { en: "Blue", de: "Blau" } }
   ];
 
-  return new uc.setup.RequestUserInput({ en: "Please choose", de: "Bitte auswählen" }, [
+  return new uc.RequestUserInput({ en: "Please choose", de: "Bitte auswählen" }, [
     {
       id: "info",
       label: { en: "Setup flow example", de: "Setup Flow Beispiel" },
@@ -96,23 +113,23 @@ async function handleDriverSetup(msg) {
  * Process user data response in a setup process.
  *
  * Driver setup callback to provide requested user data during the setup process.
- * @param {uc.setup.UserDataResponse} msg response data from the requested user data
+ * @param {uc.UserDataResponse} msg response data from the requested user data
  * @return the SetupAction on how to continue: SetupComplete if finished.
  */
 async function handleUserDataResponse(msg) {
   // values from all screens are returned: check in reverse order
   if ("step2.count" in msg.inputValues) {
     for (let x = 0; x < parseInt(msg.inputValues["step2.count"]); x++) {
-      uc.addAvailableEntity(new uc.entities.Button(`button${x}`, `Button ${x + 1}`, { cmdHandler }));
+      driver.addAvailableEntity(new uc.Button(`button${x}`, `Button ${x + 1}`, { cmdHandler }));
     }
 
-    return new uc.setup.SetupComplete();
+    return new uc.SetupComplete();
   }
 
   if ("step1.choice" in msg.inputValues) {
     const choice = msg.inputValues["step1.choice"];
     console.log("Chosen color:", choice);
-    return new uc.setup.RequestUserInput({ en: "Step 2" }, [
+    return new uc.RequestUserInput({ en: "Step 2" }, [
       {
         id: "info",
         label: {
@@ -139,27 +156,12 @@ async function handleUserDataResponse(msg) {
   }
 
   console.log("No choice was received");
-  return new uc.setup.SetupError();
+  return new uc.SetupError();
 }
 
-/**
- * Push button command handler.
- *
- * Called by the integration-API if a command is sent to a configured button-entity.
- *
- * @param {Entity} entity button entity
- * @param {string} cmdId command
- * @param {Object<string, *>} [_params] optional command parameters (not used for buttons)
- * @return {Promise<uc.StatusCodes>} status of the command
- */
-const cmdHandler = async function (entity, cmdId, _params) {
-  console.log("Got %s command request: %s", entity.id, cmdId);
-  return uc.StatusCodes.Ok;
-};
-
-uc.on(uc.Events.Connect, async () => {
+driver.on(uc.Events.Connect, async () => {
   // When the remote connects, we just set the device state. We are ready all the time!
-  await uc.setDeviceState(uc.DeviceStates.Connected);
+  await driver.setDeviceState(uc.DeviceStates.Connected);
 });
 
-uc.init("setup_flow.json", driverSetupHandler);
+driver.init("setup_flow.json", driverSetupHandler);

--- a/index.ts
+++ b/index.ts
@@ -519,7 +519,7 @@ class IntegrationAPI extends EventEmitter {
       this.emit(api.Events.EntityCommand, wsHandle, data.entity_id, data.entity_type, data.cmd_id, data.params);
     } else {
       const result = await entity.command(cmdId, "params" in data ? data.params : undefined);
-      await this.acknowledgeCommand(wsHandle);
+      await this.acknowledgeCommand(wsHandle, result);
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,8 @@
 import os from "os";
 import fs from "fs";
 import log from "./lib/loggers.js";
-import Bonjour from "bonjour-service";
+import BonjourModule from "bonjour-service";
+const Bonjour = BonjourModule.default;
 import WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { EventEmitter } from "events";
@@ -127,7 +128,15 @@ class IntegrationAPI extends EventEmitter {
     this.#driverInfo.driver_url = this.#getDriverUrl(this.#driverInfo.driver_url, port);
 
     if (!disableMdnsPublish) {
-      let bonjour = new Bonjour.default();
+      let bonjour;
+      if (integrationInterface) {
+        // TODO open issue, no longer to set advertisement network interface: https://github.com/onlxltd/bonjour-service/issues/58
+        // bonjour = new Bonjour({ interface: integrationInterface });
+        bonjour = new Bonjour();
+      } else {
+        bonjour = new Bonjour();
+      }
+
       log.debug("Starting mdns advertising");
 
       // Make sure to advertise a .local hostname. It seems that bonjour just blindly takes the hostname, short or FQDN.

--- a/index.ts
+++ b/index.ts
@@ -673,9 +673,8 @@ class IntegrationAPI extends EventEmitter {
 
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
   getDriverVersion() {
-    // TODO use getDefaultName function to get name: en might not be defined!
     return {
-      name: this.#driverInfo.name.en,
+      name: getDefaultLanguageString(this.#driverInfo.name),
       version: {
         api: this.#driverInfo.min_core_api,
         driver: this.#driverInfo.version

--- a/index.ts
+++ b/index.ts
@@ -100,7 +100,7 @@ class IntegrationAPI extends EventEmitter {
     if (typeof driverConfig === "string") {
       this.#driverPath = driverConfig;
 
-      let raw: string | Buffer;
+      let raw: Buffer;
       try {
         raw = fs.readFileSync(this.#driverPath);
       } catch (e) {
@@ -108,7 +108,7 @@ class IntegrationAPI extends EventEmitter {
       }
 
       try {
-        this.#driverInfo = JSON.parse(String(raw));
+        this.#driverInfo = JSON.parse(raw.toString());
         log.debug("Driver info loaded");
       } catch (e) {
         log.error(`Error parsing driver info: ${e}`);

--- a/index.ts
+++ b/index.ts
@@ -152,7 +152,7 @@ class IntegrationAPI extends EventEmitter {
         txt: {
           name: getDefaultLanguageString(this.#driverInfo.name, "Unknown driver"),
           ver: this.#driverInfo.version,
-          developer: this.#driverInfo.developer?.name || "",
+          developer: this.#driverInfo.developer?.name || ""
         }
       });
     }
@@ -577,9 +577,9 @@ class IntegrationAPI extends EventEmitter {
         await this.requestDriverSetupUserConfirmation(
           wsHandle,
           action.title,
-          String(action.header),
-          undefined,
-          String(action.footer)
+          action.header,
+          action.image,
+          action.footer
         );
         result = true;
       } else if (action instanceof api.SetupComplete) {
@@ -650,9 +650,9 @@ class IntegrationAPI extends EventEmitter {
         await this.requestDriverSetupUserConfirmation(
           wsHandle,
           action.title,
-          String(action.header),
-          undefined,
-          String(action.footer)
+          action.header,
+          action.image,
+          action.footer
         );
         result = true;
       } else if (action instanceof api.SetupComplete) {

--- a/lib/api_definitions.ts
+++ b/lib/api_definitions.ts
@@ -239,19 +239,3 @@ export class SetupError extends SetupAction {
 export class SetupComplete extends SetupAction {
   // Marks setup as complete
 }
-
-const setup = {
-  IntegrationSetupError,
-  SetupDriver,
-  DriverSetupRequest,
-  UserDataResponse,
-  UserConfirmationResponse,
-  AbortDriverSetup,
-  SetupAction,
-  RequestUserInput,
-  RequestUserConfirmation,
-  SetupError,
-  SetupComplete
-};
-
-export default setup;

--- a/lib/entities/button.ts
+++ b/lib/entities/button.ts
@@ -9,21 +9,21 @@
 import { CommandHandler, Entity, EntityType, EntityName } from "./entity.js";
 import log from "../loggers.js";
 
-export enum States {
+export enum ButtonStates {
   Unavailable = "UNAVAILABLE",
   Available = "AVAILABLE"
 }
 
-export enum Attributes {
+export enum ButtonAttributes {
   State = "state"
 }
 
-export enum Commands {
+export enum ButtonCommands {
   Push = "push"
 }
 
-interface ButtonParams {
-  state?: States;
+export interface ButtonParams {
+  state?: ButtonStates;
   area?: string;
   cmdHandler?: CommandHandler;
 }
@@ -33,10 +33,6 @@ interface ButtonParams {
  * for more information.
  */
 export class Button extends Entity {
-  static States = States;
-  static Attributes = Attributes;
-  static Commands = Commands;
-
   /**
    * Constructs a new button entity.
    *
@@ -49,7 +45,7 @@ export class Button extends Entity {
    * @param {ButtonParams} [params] Entity parameters.
    * @throws AssertionError if invalid parameters are specified.
    */
-  constructor(id: string, name: EntityName, { state = States.Available, area, cmdHandler }: ButtonParams = {}) {
+  constructor(id: string, name: EntityName, { state = ButtonStates.Available, area, cmdHandler }: ButtonParams = {}) {
     super(id, name, EntityType.Button, {
       features: ["press"],
       attributes: {

--- a/lib/entities/climate.ts
+++ b/lib/entities/climate.ts
@@ -10,7 +10,7 @@ import { CommandHandler, Entity, EntityType, EntityName } from "./entity.js";
 import log from "../loggers.js";
 
 // Climate entity states
-export enum States {
+export enum ClimateStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   Off = "OFF",
@@ -22,7 +22,7 @@ export enum States {
 }
 
 // Climate entity features
-export enum Features {
+export enum ClimateFeatures {
   OnOff = "on_off",
   Heat = "heat",
   Cool = "cool",
@@ -33,7 +33,7 @@ export enum Features {
 }
 
 // Climate entity attributes
-export enum Attributes {
+export enum ClimateAttributes {
   State = "state",
   CurrentTemperature = "current_temperature",
   TargetTemperature = "target_temperature",
@@ -43,7 +43,7 @@ export enum Attributes {
 }
 
 // Climate entity commands
-export enum Commands {
+export enum ClimateCommands {
   On = "on",
   Off = "off",
   HvacMode = "hvac_mode",
@@ -53,10 +53,10 @@ export enum Commands {
 }
 
 // Climate entity device classes
-export enum DeviceClasses {}
+export enum ClimateDeviceClasses {}
 
 // Climate entity options
-export enum Options {
+export enum ClimateOptions {
   TemperatureUnit = "temperature_unit",
   TargetTemperatureStep = "target_temperature_step",
   MaxTemperature = "max_temperature",
@@ -70,23 +70,16 @@ export enum TemperatureUnit {
 }
 
 // Define types for the parameters in the constructor
-interface ClimateParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States | number>>;
+export interface ClimateParams {
+  features?: ClimateFeatures[];
+  attributes?: Partial<Record<ClimateAttributes, ClimateStates | number>>;
   deviceClass?: string;
-  options?: Partial<Record<Options, TemperatureUnit | number>>;
+  options?: Partial<Record<ClimateOptions, TemperatureUnit | number>>;
   area?: string;
   cmdHandler?: CommandHandler;
 }
 
 export class Climate extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-
   /**
    * Constructs a new climate entity.
    *

--- a/lib/entities/cover.ts
+++ b/lib/entities/cover.ts
@@ -10,7 +10,7 @@ import { CommandHandler, Entity, EntityType, EntityName } from "./entity.js";
 import log from "../loggers.js";
 
 // Cover entity states
-export enum States {
+export enum CoverStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   Opening = "OPENING",
@@ -20,7 +20,7 @@ export enum States {
 }
 
 // Cover entity features
-export enum Features {
+export enum CoverFeatures {
   Open = "open",
   Close = "close",
   Stop = "stop",
@@ -31,14 +31,14 @@ export enum Features {
 }
 
 // Cover entity attributes
-export enum Attributes {
+export enum CoverAttributes {
   State = "state",
   Position = "position",
   TiltPosition = "tilt_position"
 }
 
 // Cover entity commands
-export enum Commands {
+export enum CoverCommands {
   Open = "open",
   Close = "close",
   Stop = "stop",
@@ -50,7 +50,7 @@ export enum Commands {
 }
 
 // Cover entity device classes
-export enum DeviceClasses {
+export enum CoverDeviceClasses {
   Blind = "blind",
   Curtain = "curtain",
   Garage = "garage",
@@ -61,26 +61,19 @@ export enum DeviceClasses {
 }
 
 // Cover entity options
-export enum Options {}
+export enum CoverOptions {}
 
 // Define types for the parameters in the constructor
-interface CoverParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States | number>>;
-  deviceClass?: DeviceClasses;
+export interface CoverParams {
+  features?: CoverFeatures[];
+  attributes?: Partial<Record<CoverAttributes, CoverStates | number>>;
+  deviceClass?: CoverDeviceClasses;
   options?: { [key: string]: string };
   area?: string;
   cmdHandler?: CommandHandler;
 }
 
 export class Cover extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-
   /**
    * Constructs a new cover entity.
    *

--- a/lib/entities/entities.ts
+++ b/lib/entities/entities.ts
@@ -5,21 +5,12 @@
  * @license Apache License 2.0, see LICENSE for more details.
  */
 
-import { EntityType } from "./entity.js";
 import { EventEmitter } from "events";
 import { Entity } from "./entity.js";
-import { Button } from "./button.js";
-import { Climate } from "./climate.js";
-import { Cover } from "./cover.js";
-import { Light } from "./light.js";
-import { MediaPlayer } from "./media_player.js";
-import { Remote } from "./remote.js";
-import { Sensor } from "./sensor.js";
-import { Switch } from "./switch.js";
 import { Events } from "../api_definitions.js";
 import log from "../loggers.js";
 
-class Entities extends EventEmitter {
+export class Entities extends EventEmitter {
   #storage: { [key: string]: Entity };
 
   constructor(public id: string) {
@@ -127,5 +118,3 @@ class Entities extends EventEmitter {
     this.#storage = {};
   }
 }
-
-export { EntityType, Entities, Entity, Button, Climate, Cover, Light, MediaPlayer, Remote, Sensor, Switch };

--- a/lib/entities/light.ts
+++ b/lib/entities/light.ts
@@ -12,7 +12,7 @@ import log from "../loggers.js";
 /**
  * Light entity states.
  */
-export enum States {
+export enum LightStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   On = "ON",
@@ -22,7 +22,7 @@ export enum States {
 /**
  * Light entity features.
  */
-export enum Features {
+export enum LightFeatures {
   OnOff = "on_off",
   Toggle = "toggle",
   Dim = "dim",
@@ -33,7 +33,7 @@ export enum Features {
 /**
  * Light entity attributes.
  */
-export enum Attributes {
+export enum LightAttributes {
   State = "state",
   Hue = "hue",
   Saturation = "saturation",
@@ -44,7 +44,7 @@ export enum Attributes {
 /**
  * Light entity commands.
  */
-export enum Commands {
+export enum LightCommands {
   On = "on",
   Off = "off",
   Toggle = "toggle"
@@ -53,20 +53,20 @@ export enum Commands {
 /**
  * Light entity device classes.
  */
-export enum DeviceClasses {}
+export enum LightDeviceClasses {}
 
 /**
  * Light entity options.
  */
-export enum Options {
+export enum LightOptions {
   ColorTemperatureSteps = "color_temperature_steps"
 }
 
-interface LightParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States | number>>;
+export interface LightParams {
+  features?: LightFeatures[];
+  attributes?: Partial<Record<LightAttributes, LightStates | number>>;
   deviceClass?: string;
-  options?: Partial<Record<Options, number>>;
+  options?: Partial<Record<LightOptions, number>>;
   area?: string;
   cmdHandler?: CommandHandler;
 }
@@ -76,13 +76,6 @@ interface LightParams {
  * for more information.
  */
 export class Light extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-
   /**
    * Constructs a new light entity.
    *

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -12,7 +12,7 @@ import log from "../loggers.js";
 /**
  * Media-player entity states.
  */
-export enum States {
+export enum MediaPlayerStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   On = "ON",
@@ -26,7 +26,7 @@ export enum States {
 /**
  * Media-player entity features.
  */
-export enum Features {
+export enum MediaPlayerFeatures {
   OnOff = "on_off",
   Toggle = "toggle",
   Volume = "volume",
@@ -72,7 +72,7 @@ export enum Features {
 /**
  * Media-player entity attributes.
  */
-export enum Attributes {
+export enum MediaPlayerAttributes {
   State = "state",
   Volume = "volume",
   Muted = "muted",
@@ -94,7 +94,7 @@ export enum Attributes {
 /**
  * Media-player entity commands.
  */
-export enum Commands {
+export enum MediaPlayerCommands {
   On = "on",
   Off = "off",
   Toggle = "toggle",
@@ -156,7 +156,7 @@ export enum Commands {
 /**
  * Media-player entity device classes.
  */
-export enum DeviceClasses {
+export enum MediaPlayerDeviceClasses {
   Receiver = "receiver",
   SetTopBox = "set_top_box",
   Speaker = "speaker",
@@ -167,7 +167,7 @@ export enum DeviceClasses {
 /**
  * Media-player entity options.
  */
-export enum Options {
+export enum MediaPlayerOptions {
   SimpleCommands = "simple_commands",
   VolumeSteps = "volume_steps"
 }
@@ -194,11 +194,13 @@ export enum RepeatMode {
 
 //export type CmdHandler = (entity: Entity, command: string, options?: Record<string, unknown>) => Promise<string>;
 
-interface MediaPlayerParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States | RepeatMode | string | string[] | number | boolean>>;
-  deviceClass?: DeviceClasses;
-  options?: Partial<Record<Options, string[] | number>>;
+export interface MediaPlayerParams {
+  features?: MediaPlayerFeatures[];
+  attributes?: Partial<
+    Record<MediaPlayerAttributes, MediaPlayerStates | RepeatMode | string | string[] | number | boolean>
+  >;
+  deviceClass?: MediaPlayerDeviceClasses;
+  options?: Partial<Record<MediaPlayerOptions, string[] | number>>;
   area?: string;
   cmdHandler?: CommandHandler;
 }
@@ -209,15 +211,6 @@ interface MediaPlayerParams {
  */
 
 export class MediaPlayer extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-  static MediaType = MediaType;
-  static RepeatMode = RepeatMode;
-
   /**
    * Constructs a new media-player entity.
    *

--- a/lib/entities/remote.ts
+++ b/lib/entities/remote.ts
@@ -14,7 +14,7 @@ import assert from "node:assert";
 /**
  * Remote entity states.
  */
-export enum States {
+export enum RemoteStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   On = "ON",
@@ -24,7 +24,7 @@ export enum States {
 /**
  * Remote-entity features.
  */
-export enum Features {
+export enum RemoteFeatures {
   OnOff = "on_off",
   Toggle = "toggle",
   SendCmd = "send_cmd"
@@ -33,14 +33,14 @@ export enum Features {
 /**
  * Remote-entity attributes.
  */
-export enum Attributes {
+export enum RemoteAttributes {
   State = "state"
 }
 
 /**
  * Remote-entity commands.
  */
-export enum Commands {
+export enum RemoteCommands {
   On = "on",
   Off = "off",
   Toggle = "toggle",
@@ -51,7 +51,7 @@ export enum Commands {
 /**
  * Remote-entity options.
  */
-export enum Options {
+export enum RemoteOptions {
   SimpleCommands = "simple_commands",
   ButtonMapping = "button_mapping",
   UserInterface = "user_interface"
@@ -84,7 +84,7 @@ export function createSendCmd(
     params.hold = hold;
   }
 
-  return new EntityCommand(Commands.SendCmd, params);
+  return new EntityCommand(RemoteCommands.SendCmd, params);
 }
 
 /**
@@ -106,19 +106,19 @@ export function createSequenceCmd(
   );
 
   const params: Record<string, string[] | number> = { sequence };
-  if (typeof delay === "number") {
+  if (delay !== undefined) {
     params.delay = delay;
   }
-  if (typeof repeat === "number") {
+  if (repeat !== undefined) {
     params.repeat = repeat;
   }
 
-  return new EntityCommand(Commands.SendCmdSequence, params);
+  return new EntityCommand(RemoteCommands.SendCmdSequence, params);
 }
 
-interface RemoteParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States>>;
+export interface RemoteParams {
+  features?: RemoteFeatures[];
+  attributes?: Partial<Record<RemoteAttributes, RemoteStates>>;
   simpleCommands?: string[];
   buttonMapping?: DeviceButtonMapping[];
   uiPages?: UiPage[];
@@ -127,12 +127,7 @@ interface RemoteParams {
 }
 
 export class Remote extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static Options = Options;
-
+  // TODO this doesn't look right, and we have a double export!
   static createSendCmd = createSendCmd;
   static createSequenceCmd = createSequenceCmd;
 
@@ -151,13 +146,13 @@ export class Remote extends Entity {
   ) {
     const options: { [key: string]: string | number | boolean | object } = {};
     if (simpleCommands) {
-      options[Options.SimpleCommands] = simpleCommands;
+      options[RemoteOptions.SimpleCommands] = simpleCommands;
     }
     if (buttonMapping) {
-      options[Options.ButtonMapping] = buttonMapping;
+      options[RemoteOptions.ButtonMapping] = buttonMapping;
     }
     if (uiPages) {
-      options[Options.UserInterface] = { pages: uiPages };
+      options[RemoteOptions.UserInterface] = { pages: uiPages };
     }
 
     super(id, name, EntityType.Remote, { features, attributes, options, area, cmdHandler });

--- a/lib/entities/remote.ts
+++ b/lib/entities/remote.ts
@@ -67,11 +67,11 @@ export enum RemoteOptions {
  * @return EntityCommand the created EntityCommand.
  * @throws AssertionError if command is not specified or is empty.
  */
-export function createSendCmd(
-  command: string | undefined,
+export function createRemoteSendCmd(
+  command: string,
   { delay, repeat, hold }: { delay?: number; repeat?: number; hold?: number } = {}
 ): EntityCommand {
-  assert(command && command.length > 0, "command must be a string and may not be empty");
+  assert(command && command.length > 0, "command may not be empty");
 
   const params: Record<string, string | number> = { command };
   if (delay) {
@@ -96,12 +96,12 @@ export function createSendCmd(
  * @return EntityCommand the created EntityCommand.
  * @throws AssertionError if sequence is not specified or doesn't contain at least one command.
  */
-export function createSequenceCmd(
-  sequence: string[] | undefined,
+export function createRemoteSequenceCmd(
+  sequence: string[],
   { delay, repeat }: { delay?: number; repeat?: number } = {}
 ): EntityCommand {
   assert(
-    sequence && Array.isArray(sequence) && sequence.length > 0,
+    Array.isArray(sequence) && sequence.length > 0,
     "sequence array must be specified and contain at least one command"
   );
 
@@ -127,10 +127,6 @@ export interface RemoteParams {
 }
 
 export class Remote extends Entity {
-  // TODO this doesn't look right, and we have a double export!
-  static createSendCmd = createSendCmd;
-  static createSequenceCmd = createSequenceCmd;
-
   /**
    * Constructs a new remote-entity.
    *

--- a/lib/entities/sensor.ts
+++ b/lib/entities/sensor.ts
@@ -12,7 +12,7 @@ import log from "../loggers.js";
 /**
  * Sensor entity states.
  */
-export enum States {
+export enum SensorStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   On = "ON"
@@ -21,12 +21,12 @@ export enum States {
 /**
  * Sensor entity features.
  */
-export enum Features {}
+export enum SensorFeatures {}
 
 /**
  * Sensor entity attributes.
  */
-export enum Attributes {
+export enum SensorAttributes {
   State = "state",
   Value = "value",
   Unit = "unit"
@@ -35,12 +35,12 @@ export enum Attributes {
 /**
  * Sensor entity commands.
  */
-export enum Commands {}
+export enum SensorCommands {}
 
 /**
  * Sensor entity device classes.
  */
-export enum DeviceClasses {
+export enum SensorDeviceClasses {
   Custom = "custom",
   Battery = "battery",
   Current = "current",
@@ -54,7 +54,7 @@ export enum DeviceClasses {
 /**
  * Sensor entity options.
  */
-export enum Options {
+export enum SensorOptions {
   CustomUnit = "custom_unit",
   NativeUnit = "native_unit",
   Decimals = "decimals",
@@ -62,21 +62,14 @@ export enum Options {
   MaxValue = "max_value"
 }
 
-interface SensorParams {
-  attributes?: Partial<Record<Attributes, States | number | string>>;
-  deviceClass?: DeviceClasses;
-  options?: Partial<Record<Options, string | number>>;
+export interface SensorParams {
+  attributes?: Partial<Record<SensorAttributes, SensorStates | number | string>>;
+  deviceClass?: SensorDeviceClasses;
+  options?: Partial<Record<SensorOptions, string | number>>;
   area?: string;
 }
 
 export class Sensor extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-
   /**
    * Constructs a new sensor entity.
    *

--- a/lib/entities/switch.ts
+++ b/lib/entities/switch.ts
@@ -10,7 +10,7 @@ import { CommandHandler, Entity, EntityType, EntityName } from "./entity.js";
 import log from "../loggers.js";
 
 // Switch entity states
-export enum States {
+export enum SwitchStates {
   Unavailable = "UNAVAILABLE",
   Unknown = "UNKNOWN",
   On = "ON",
@@ -18,40 +18,40 @@ export enum States {
 }
 
 // Switch entity features
-export enum Features {
+export enum SwitchFeatures {
   OnOff = "on_off",
   Toggle = "toggle"
 }
 
 // Switch entity attributes
-export enum Attributes {
+export enum SwitchAttributes {
   State = "state"
 }
 
 // Switch entity commands
-export enum Commands {
+export enum SwitchCommands {
   On = "on",
   Off = "off",
   Toggle = "toggle"
 }
 
 // Switch entity device classes
-export enum DeviceClasses {
+export enum SwitchDeviceClasses {
   Outlet = "outlet",
   Switch = "switch"
 }
 
 // Switch entity options
-export enum Options {
+export enum SwitchOptions {
   Readable = "readable"
 }
 
 // Define types for the parameters in the constructor
-interface SwitchParams {
-  features?: Features[];
-  attributes?: Partial<Record<Attributes, States>>;
-  deviceClass?: DeviceClasses;
-  options?: Partial<Record<Options, boolean>>;
+export interface SwitchParams {
+  features?: SwitchFeatures[];
+  attributes?: Partial<Record<SwitchAttributes, SwitchStates>>;
+  deviceClass?: SwitchDeviceClasses;
+  options?: Partial<Record<SwitchOptions, boolean>>;
   area?: string;
   cmdHandler?: CommandHandler;
 }
@@ -61,13 +61,6 @@ interface SwitchParams {
  * for more information.
  */
 export class Switch extends Entity {
-  static States = States;
-  static Features = Features;
-  static Attributes = Attributes;
-  static Commands = Commands;
-  static DeviceClasses = DeviceClasses;
-  static Options = Options;
-
   /**
    * Constructs a new switch entity.
    *

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,10 +23,8 @@ export function toLanguageObject(
     if (text instanceof Map) {
       return Object.fromEntries(text);
     }
-    if (text instanceof Object) {
-      // TODO check if text object only contains string keys & values?
-      return text;
-    }
+    // TODO check if text object only contains string keys & values?
+    return text;
   }
 
   return null;

--- a/test/button.test.ts
+++ b/test/button.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { Button, States } from "../lib/entities/button.js";
+import { Button, ButtonStates } from "../lib/entities/button.js";
 import { EntityType } from "../lib/entities/entity.js";
 
 test("Button constructor without parameter object creates default Button class", (t) => {
@@ -19,7 +19,7 @@ test("Button constructor without parameter object creates default Button class",
 
 test("Button constructor with parameter object", (t) => {
   const entity = new Button("test", "Test Button", {
-    state: States.Unavailable,
+    state: ButtonStates.Unavailable,
     area: "Test lab"
   });
 

--- a/test/climate.test.ts
+++ b/test/climate.test.ts
@@ -1,5 +1,12 @@
 import test from "ava";
-import { Climate, Options, Features, States, Attributes, TemperatureUnit } from "../lib/entities/climate.js";
+import {
+  Climate,
+  ClimateOptions,
+  ClimateFeatures,
+  ClimateStates,
+  ClimateAttributes,
+  TemperatureUnit
+} from "../lib/entities/climate.js";
 import { EntityType } from "../lib/entities/entity.js";
 
 test("Climate constructor without parameter object creates default Climate class", (t) => {
@@ -18,14 +25,14 @@ test("Climate constructor without parameter object creates default Climate class
 });
 
 test("Climate constructor with parameter object", (t) => {
-  const options: Partial<Record<Options, TemperatureUnit | number>> = {
-    [Options.TemperatureUnit]: TemperatureUnit.Celsius
+  const options: Partial<Record<ClimateOptions, TemperatureUnit | number>> = {
+    [ClimateOptions.TemperatureUnit]: TemperatureUnit.Celsius
   };
 
   const entity = new Climate("test", "Test Climate", {
-    features: [Features.Cool],
+    features: [ClimateFeatures.Cool],
     attributes: {
-      [Attributes.State]: States.Unavailable
+      [ClimateAttributes.State]: ClimateStates.Unavailable
     },
     options,
     area: "Test lab"
@@ -46,7 +53,7 @@ test("Climate constructor with parameter object", (t) => {
 test("Climate constructor with Object attributes", (t) => {
   const entity = new Climate("test", "Test Climate", {
     attributes: {
-      [Attributes.State]: States.Cool
+      [ClimateAttributes.State]: ClimateStates.Cool
     }
   });
 

--- a/test/cover.test.ts
+++ b/test/cover.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { Cover, Features, Attributes, States } from "../lib/entities/cover.js";
+import { Cover, CoverFeatures, CoverAttributes, CoverStates } from "../lib/entities/cover.js";
 import { EntityType } from "../lib/entities/entity.js";
 
 test("Cover constructor without parameter object creates default Cover class", (t) => {
@@ -18,12 +18,12 @@ test("Cover constructor without parameter object creates default Cover class", (
 });
 
 test("Cover constructor with parameter object", (t) => {
-  const attributes: Partial<Record<Attributes, States | number>> = {
-    [Attributes.State]: States.Unavailable
+  const attributes: Partial<Record<CoverAttributes, CoverStates | number>> = {
+    [CoverAttributes.State]: CoverStates.Unavailable
   };
 
   const entity = new Cover("test", "Test Cover", {
-    features: [Features.Tilt],
+    features: [CoverFeatures.Tilt],
     attributes,
     options: {},
     area: "Test lab"

--- a/test/light.test.ts
+++ b/test/light.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { Light, Features, States, Attributes } from "../lib/entities/light.js";
+import { Light, LightFeatures, LightStates, LightAttributes } from "../lib/entities/light.js";
 import { EntityType } from "../lib/entities/entity.js";
 
 test("Light constructor without parameter object creates default Light class", (t) => {
@@ -18,12 +18,12 @@ test("Light constructor without parameter object creates default Light class", (
 });
 
 test("Light constructor with parameter object", (t) => {
-  const attributes: Partial<Record<Attributes, States | number>> = {
-    [Attributes.State]: States.Unavailable
+  const attributes: Partial<Record<LightAttributes, LightStates | number>> = {
+    [LightAttributes.State]: LightStates.Unavailable
   };
 
   const entity = new Light("test", "Test Light", {
-    features: [Features.ColorTemperature],
+    features: [LightFeatures.ColorTemperature],
     attributes,
     options: {},
     area: "Test lab"

--- a/test/media_player.test.ts
+++ b/test/media_player.test.ts
@@ -1,5 +1,11 @@
 import test from "ava";
-import { MediaPlayer, Options, Features, States, Attributes } from "../lib/entities/media_player.js";
+import {
+  MediaPlayer,
+  MediaPlayerOptions,
+  MediaPlayerFeatures,
+  MediaPlayerStates,
+  MediaPlayerAttributes
+} from "../lib/entities/media_player.js";
 import { EntityType } from "../lib/entities/entity.js";
 
 test("MediaPlayer constructor without parameter object creates default MediaPlayer class", (t) => {
@@ -18,17 +24,17 @@ test("MediaPlayer constructor without parameter object creates default MediaPlay
 });
 
 test("MediaPlayer constructor with parameter object", (t) => {
-  const options: Partial<Record<Options, number>> = {
-    [Options.VolumeSteps]: 10
+  const options: Partial<Record<MediaPlayerOptions, number>> = {
+    [MediaPlayerOptions.VolumeSteps]: 10
   };
 
-  const attributes: Partial<Record<Attributes, States | number>> = {
-    [Attributes.State]: States.Unavailable,
-    [Attributes.Volume]: 22
+  const attributes: Partial<Record<MediaPlayerAttributes, MediaPlayerStates | number>> = {
+    [MediaPlayerAttributes.State]: MediaPlayerStates.Unavailable,
+    [MediaPlayerAttributes.Volume]: 22
   };
 
   const entity = new MediaPlayer("test", "Test MediaPlayer", {
-    features: [Features.Menu],
+    features: [MediaPlayerFeatures.Menu],
     attributes,
     options,
     area: "Test lab"
@@ -47,10 +53,10 @@ test("MediaPlayer constructor with parameter object", (t) => {
 });
 
 test("MediaPlayer constructor with Object attributes", (t) => {
-  const defaultAttributes: Partial<Record<Attributes, number | boolean>> = {
-    [Attributes.Shuffle]: false,
-    [Attributes.Muted]: false,
-    [Attributes.Volume]: 25
+  const defaultAttributes: Partial<Record<MediaPlayerAttributes, number | boolean>> = {
+    [MediaPlayerAttributes.Shuffle]: false,
+    [MediaPlayerAttributes.Muted]: false,
+    [MediaPlayerAttributes.Volume]: 25
   };
 
   const entity = new MediaPlayer("test", "Test MediaPlayer", {

--- a/test/remote.test.ts
+++ b/test/remote.test.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import {
-  createSequenceCmd,
-  createSendCmd,
+  createRemoteSequenceCmd,
+  createRemoteSendCmd,
   RemoteFeatures,
   RemoteStates,
   RemoteAttributes
@@ -14,7 +14,9 @@ import { EntityType } from "../lib/entities/entity.js";
 test("createSequenceCmd with an undefined sequence throws an assert", (t) => {
   t.throws(
     () => {
-      createSequenceCmd(undefined);
+      // force an invalid type for old JS integration drivers
+      const jsTest: any = undefined;
+      createRemoteSequenceCmd(jsTest);
     },
     { instanceOf: AssertionError }
   );
@@ -23,40 +25,36 @@ test("createSequenceCmd with an undefined sequence throws an assert", (t) => {
 test("createSequenceCmd with an empty sequence array throws an assert", (t) => {
   t.throws(
     () => {
-      createSequenceCmd([]);
+      createRemoteSequenceCmd([]);
     },
     { instanceOf: AssertionError }
   );
 });
 
 test("createSequenceCmd without optional params doesn't include fields", (t) => {
-  const result = createSequenceCmd(["foo", "bar"]);
+  const result = createRemoteSequenceCmd(["foo", "bar"]);
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd_sequence");
   t.deepEqual(result.params, { sequence: ["foo", "bar"] });
 });
 
 test("createSequenceCmd with value 0 for delay and repeat returns values", (t) => {
-  const result = createSequenceCmd(["foo", "bar"], { delay: 0, repeat: 0 });
+  const result = createRemoteSequenceCmd(["foo", "bar"], { delay: 0, repeat: 0 });
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd_sequence");
   t.deepEqual(result.params, { sequence: ["foo", "bar"], delay: 0, repeat: 0 });
 });
 
 test("createSequenceCmd with delay returns parameter field", (t) => {
-  const result = createSequenceCmd(["foo", "bar"], { delay: 100 });
+  const result = createRemoteSequenceCmd(["foo", "bar"], { delay: 100 });
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd_sequence");
   t.deepEqual(result.params, { sequence: ["foo", "bar"], delay: 100 });
 });
 
 test("createSequenceCmd with repeat returns parameter field", (t) => {
-  const result = createSequenceCmd(["foo", "bar"], { repeat: 2 });
+  const result = createRemoteSequenceCmd(["foo", "bar"], { repeat: 2 });
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd_sequence");
   t.deepEqual(result.params, { sequence: ["foo", "bar"], repeat: 2 });
 });
@@ -64,7 +62,9 @@ test("createSequenceCmd with repeat returns parameter field", (t) => {
 test("createSendCmd with an undefined command throws an assert", (t) => {
   t.throws(
     () => {
-      createSendCmd(undefined);
+      // force an invalid type for old JS integration drivers
+      const jsTest: any = undefined;
+      createRemoteSendCmd(jsTest);
     },
     { instanceOf: AssertionError }
   );
@@ -73,24 +73,22 @@ test("createSendCmd with an undefined command throws an assert", (t) => {
 test("createSendCmd with an empty command throws an assert", (t) => {
   t.throws(
     () => {
-      createSendCmd("");
+      createRemoteSendCmd("");
     },
     { instanceOf: AssertionError }
   );
 });
 
 test("createSendCmd without optional params doesn't include fields", (t) => {
-  const result = createSendCmd("foobar");
+  const result = createRemoteSendCmd("foobar");
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd");
   t.deepEqual(result.params, { command: "foobar" });
 });
 
 test("createSendCmd with optional params returns fields", (t) => {
-  const result = createSendCmd("foobar", { delay: 1, repeat: 2, hold: 3 });
+  const result = createRemoteSendCmd("foobar", { delay: 1, repeat: 2, hold: 3 });
 
-  t.true(result instanceof EntityCommand, "result must be an EntityCommand");
   t.is(result.cmd_id, "send_cmd");
   t.deepEqual(result.params, { command: "foobar", delay: 1, repeat: 2, hold: 3 });
 });

--- a/test/remote.test.ts
+++ b/test/remote.test.ts
@@ -1,9 +1,15 @@
 import test from "ava";
-import { createSequenceCmd, createSendCmd, Features, States, Attributes } from "../lib/entities/remote.js";
+import {
+  createSequenceCmd,
+  createSendCmd,
+  RemoteFeatures,
+  RemoteStates,
+  RemoteAttributes
+} from "../lib/entities/remote.js";
 import { EntityCommand } from "../lib/entities/ui.js";
 import { AssertionError } from "node:assert";
-import { Remote } from "../lib/entities/entities.js";
-import { EntityType } from "../lib/entities/entities.js";
+import { Remote } from "../lib/entities/remote.js";
+import { EntityType } from "../lib/entities/entity.js";
 
 test("createSequenceCmd with an undefined sequence throws an assert", (t) => {
   t.throws(
@@ -105,12 +111,12 @@ test("Remote constructor without parameter object creates default remote class",
 });
 
 test("Remote constructor with parameter object", (t) => {
-  const attributes: Partial<Record<Attributes, States>> = {
-    [Attributes.State]: States.On
+  const attributes: Partial<Record<RemoteAttributes, RemoteStates>> = {
+    [RemoteAttributes.State]: RemoteStates.On
   };
 
   const remote = new Remote("test", "Test Remote", {
-    features: [Features.SendCmd],
+    features: [RemoteFeatures.SendCmd],
     attributes,
     simpleCommands: ["foobar", "foo", "bar"],
     area: "Test lab"
@@ -130,7 +136,7 @@ test("Remote constructor with parameter object", (t) => {
 
 test("Remote constructor with Object attributes", (t) => {
   const entity = new Remote("test", "Test Remote", {
-    attributes: { state: States.Unavailable }
+    attributes: { state: RemoteStates.Unavailable }
   });
 
   t.is(entity.id, "test");

--- a/test/sensor.test.ts
+++ b/test/sensor.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { EntityType } from "../lib/entities/entity.js";
-import { Sensor, Options, States, Attributes, DeviceClasses } from "../lib/entities/sensor.js";
+import { Sensor, SensorOptions, SensorStates, SensorAttributes, SensorDeviceClasses } from "../lib/entities/sensor.js";
 
 test("Sensor constructor without parameter object creates default Sensor class", (t) => {
   const entity = new Sensor("test", "Test Sensor");
@@ -18,18 +18,18 @@ test("Sensor constructor without parameter object creates default Sensor class",
 });
 
 test("Sensor constructor with parameter object", (t) => {
-  const options: Partial<Record<Options, number>> = {
-    [Options.MaxValue]: 42
+  const options: Partial<Record<SensorOptions, number>> = {
+    [SensorOptions.MaxValue]: 42
   };
 
-  const attributes: Partial<Record<Attributes, States | number>> = {
-    [Attributes.State]: States.Unavailable
+  const attributes: Partial<Record<SensorAttributes, SensorStates | number>> = {
+    [SensorAttributes.State]: SensorStates.Unavailable
   };
 
   const entity = new Sensor("test", "Test Sensor", {
     attributes,
     options,
-    deviceClass: DeviceClasses.Energy,
+    deviceClass: SensorDeviceClasses.Energy,
     area: "Test lab"
   });
 
@@ -46,10 +46,10 @@ test("Sensor constructor with parameter object", (t) => {
 });
 
 test("Sensor constructor with Object attributes", (t) => {
-  const attributes: Partial<Record<Attributes, States | number | string>> = {
-    [Attributes.State]: States.On,
-    [Attributes.Value]: 100,
-    [Attributes.Unit]: "%"
+  const attributes: Partial<Record<SensorAttributes, SensorStates | number | string>> = {
+    [SensorAttributes.State]: SensorStates.On,
+    [SensorAttributes.Value]: 100,
+    [SensorAttributes.Unit]: "%"
   };
 
   const entity = new Sensor("test", "Test Sensor", {

--- a/test/switch.test.ts
+++ b/test/switch.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { EntityType } from "../lib/entities/entity.js";
-import { Switch, Options, Features, Attributes, States } from "../lib/entities/switch.js";
+import { Switch, SwitchOptions, SwitchFeatures, SwitchAttributes, SwitchStates } from "../lib/entities/switch.js";
 
 test("Switch constructor without parameter object creates default Switch class", (t) => {
   const entity = new Switch("test", "Test Switch");
@@ -18,16 +18,16 @@ test("Switch constructor without parameter object creates default Switch class",
 });
 
 test("Switch constructor with parameter object", (t) => {
-  const options: Record<Options, boolean> = {
-    [Options.Readable]: true
+  const options: Record<SwitchOptions, boolean> = {
+    [SwitchOptions.Readable]: true
   };
 
-  const attributes: Partial<Record<Attributes, States>> = {
-    [Attributes.State]: States.Unavailable
+  const attributes: Partial<Record<SwitchAttributes, SwitchStates>> = {
+    [SwitchAttributes.State]: SwitchStates.Unavailable
   };
 
   const entity = new Switch("test", "Test Switch", {
-    features: [Features.Toggle],
+    features: [SwitchFeatures.Toggle],
     attributes,
     options,
     area: "Test lab"
@@ -47,7 +47,7 @@ test("Switch constructor with parameter object", (t) => {
 
 test("Switch constructor with Object attributes", (t) => {
   const entity = new Switch("test", "Test Switch", {
-    attributes: { state: States.Off }
+    attributes: { state: SwitchStates.Off }
   });
 
   t.is(entity.id, "test");


### PR DESCRIPTION
The JS transpiling creates a lot of mangled names and weird definitions. 

- Rename enums: prefix with entity name and export them directly.
- Export all entities and related enums directly, not under the entities alias.
  - Don't create aliases for the enums inside entities. This created double exports.

Many type definitions were missing, incomplete or even wrong. This PR fixes most of them.

Regression fixes:
- Don't suppress result code of entity command.
  This can lead to serious runtime issues preventing retry handling and not notifying the user if something goes wrong.
- IntegrationAPI.init works again with a provided configuration object.
  The TS conversion introduced a new createDriverInfo function which just throws an Error.
  - correctly define Developer and DriverInfo interfaces according to
    Integration-AsyncAPI definition.
  - add DriverInfo type to driverConfig parameter in init()
  - remove createDriverInfo function
  - fix integration port handling:
    - no need for a Number object at multiple places.
    - convert from ENV var string value once, then deal with number type.
- Don't exclude image in driver setup configuration
  This is essential for certain integration drivers and clearly documented in the AsyncAPI specification!
- Runtime errors in driver setup flow due to changed types.

Open issue: tsup doesn't do type checking. A simple tsc only solution would be preferrable. We'll look into this after this PR.