### PR TITLE
Potential fix for code scanning alert no. 63: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,9 @@ on:
     branches: ["main"]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests


### PR DESCRIPTION
Potential fix for [https://github.com/unfoldedcircle/integration-node-library/security/code-scanning/63](https://github.com/unfoldedcircle/integration-node-library/security/code-scanning/63)

In general, to fix this class of problems you explicitly declare a `permissions:` block for the workflow or for each job, granting only the scopes actually required (usually `contents: read` for simple CI jobs). This prevents the `GITHUB_TOKEN` from inheriting potentially broader repository defaults.

For this workflow, the single best fix without changing existing functionality is to add a `permissions:` block at the root level, just below the `on:` section and before `jobs:`. The job only checks out code, sets up Node, uses caching, installs dependencies, and runs tests; none of these need write access to repo contents, issues, or PRs. Therefore, a minimal and appropriate block is:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed; this is purely a YAML configuration change within `.github/workflows/unit-tests.yml`. You only need to insert these two lines with correct indentation at the workflow root.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
