### PR TITLE
Potential fix for code scanning alert no. 64: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -4,6 +4,8 @@
 # and https://eslint.org
 
 name: Check Node.js code formatting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/unfoldedcircle/integration-node-library/security/code-scanning/64](https://github.com/unfoldedcircle/integration-node-library/security/code-scanning/64)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root or within the job) that grants only the least privileges needed. For this code-formatting workflow, the job only needs to read the repository contents; it does not need to write to the repo, issues, or pull requests. Therefore, setting `permissions: contents: read` at the workflow level is sufficient and clearly documents the intended privilege level.

The best way to fix this without changing functionality is to add a root-level `permissions` block just after the `name` and before the `on:` section in `.github/workflows/code-format.yml`. This will apply to all jobs in this workflow (currently just `eslint`) and restrict `GITHUB_TOKEN` to read-only repository contents, which is enough for `actions/checkout` and the rest of the steps. No additional imports, methods, or definitions are required; this is a pure YAML configuration change.

Concretely: in `.github/workflows/code-format.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 7 (`name: Check Node.js code formatting`) and line 8 (`on:`). No other sections of the file need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
