### PR TITLE
feat: add media browsing and searching features to media-player

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Not supported:
 Requirements:
 
 - For local development and writing external integration drivers:
-  - Node.js v16.18.0 or newer (older versions are not tested).
-  - Development dependencies require at least v18.18
+  - Node.js v22.13 or newer (older versions are not supported by some dependencies).
   - Node.js version manager [nvm](https://github.com/nvm-sh/nvm) can be used to switch versions.
 - For writing custom integration drivers running on the Remote device:
-  - The Remote Two firmware up to version 1.9.2 contains Node.js v16.18
-  - Newer firmware versions contain Node.js v20.16
+  - Newer firmware versions contain Node.js v22.13
+  - The Remote Two/3 firmware up to version 2.2.4 contains Node.js v20.16
+  - The Remote Two/3 firmware up to version 1.9.2 contains Node.js v16.18
 
 ## Installation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,12 @@ and are not yet available as classes.
 See `Setting` object definition and the referenced SettingTypeNumber, SettingTypeText, SettingTypeTextArea,
 SettingTypePassword, SettingTypeCheckbox, SettingTypeDropdown, SettingTypeLabel.
 
+## media-player
+
+The [media-player](media-player/media_player.js) example shows how to implement a media player driver with media
+browsing and searching capabilities.
+It extends the `MediaPlayer` entity to override the command handler and the media callback methods.
+
 ## Driver configuration
 
 Edit `driver.json` if you'd like to change the port or any other information.

--- a/examples/media-player/media_player.js
+++ b/examples/media-player/media_player.js
@@ -115,7 +115,7 @@ class MediaPlayer extends uc.MediaPlayer {
     return uc.StatusCodes.NotImplemented;
   }
 
-  browseRoot(paging) {
+  browseRoot(_) {
     const root = new BrowseMediaItem("", "Media Directory", {
       media_class: KnownMediaClass.Directory,
       can_browse: true,

--- a/examples/media-player/media_player.js
+++ b/examples/media-player/media_player.js
@@ -1,0 +1,227 @@
+// use integration library in a client project:
+// import * as uc from "@unfoldedcircle/integration-api";
+// individual classes and enums can also be imported
+import * as uc from "../../dist/cjs/index.js";
+import {
+  BrowseMediaItem,
+  BrowseResult,
+  KnownMediaClass,
+  KnownMediaContentType,
+  MediaPlayerAttributes,
+  MediaPlayerDeviceClasses,
+  MediaPlayerFeatures,
+  MediaPlayerStates
+} from "../../dist/cjs/index.js";
+
+const driver = new uc.IntegrationAPI();
+
+driver.init("media_player.json");
+
+driver.on(uc.Events.Connect, async () => {
+  await driver.setDeviceState(uc.DeviceStates.Connected);
+});
+
+driver.on(uc.Events.Disconnect, async () => {
+  await driver.setDeviceState(uc.DeviceStates.Disconnected);
+});
+
+class MediaPlayer extends uc.MediaPlayer {
+  constructor() {
+    super(
+      "test_mediaplayer",
+      { en: "Foobar MediaPlayer" },
+      {
+        features: [
+          MediaPlayerFeatures.OnOff,
+          MediaPlayerFeatures.Dpad,
+          MediaPlayerFeatures.Home,
+          MediaPlayerFeatures.Menu,
+          MediaPlayerFeatures.ChannelSwitcher,
+          MediaPlayerFeatures.SelectSource,
+          MediaPlayerFeatures.PlayPause,
+          MediaPlayerFeatures.PlayMedia,
+          MediaPlayerFeatures.PlayMediaAction,
+          MediaPlayerFeatures.ClearPlaylist,
+          MediaPlayerFeatures.BrowseMedia,
+          MediaPlayerFeatures.SearchMedia,
+          MediaPlayerFeatures.SearchMediaClasses
+        ],
+        attributes: {
+          [MediaPlayerAttributes.State]: MediaPlayerStates.Off,
+          [MediaPlayerAttributes.SourceList]: ["Radio", "Streaming", "Favorite 1", "Favorite 2", "Favorite 3"],
+          [MediaPlayerAttributes.SearchMediaClasses]: [
+            KnownMediaClass.Album,
+            KnownMediaClass.Artist,
+            KnownMediaClass.Music,
+            KnownMediaClass.Radio
+          ]
+        },
+        deviceClass: MediaPlayerDeviceClasses.StreamingBox
+      }
+    );
+  }
+
+  async command(cmdId, params) {
+    const parameters = params ? JSON.stringify(params) : "";
+    console.log(`Got media-player command request: ${cmdId} ${parameters}`);
+
+    return uc.StatusCodes.Ok;
+  }
+
+  async browse(options) {
+    const paging = options.paging;
+    console.log(
+      "Media browsing request for %s: media_id=%s, media_type=%s, offset=%d, limit=%d",
+      this.id,
+      options.media_id,
+      options.media_type,
+      paging.offset,
+      paging.limit
+    );
+
+    if (options.media_id === undefined && options.media_type === undefined) {
+      if (paging.page > 1) {
+        return BrowseResult.empty();
+      }
+
+      return this.browseRoot(paging);
+    }
+
+    switch (options.media_id) {
+      case "favorites":
+        return this.browseFavorites(paging);
+      case "radio":
+        return this.browseRadio(paging);
+      case "albums":
+        return this.browseAlbums(paging);
+      default:
+        return BrowseResult.empty();
+    }
+  }
+
+  async search(options) {
+    const paging = options.paging;
+    console.log(
+      "Media searching request for %s: '%s', media_id=%s, media_type=%s, filter=%s, offset=%d, limit=%d",
+      this.id,
+      options.query,
+      options.media_id,
+      options.media_type,
+      JSON.stringify(options.filter),
+      paging.offset,
+      paging.limit
+    );
+
+    return uc.StatusCodes.NotImplemented;
+  }
+
+  browseRoot(paging) {
+    const root = new BrowseMediaItem("", "Media Directory", {
+      media_class: KnownMediaClass.Directory,
+      can_browse: true,
+      items: [
+        new BrowseMediaItem("favorites", "Favorites", {
+          media_class: KnownMediaClass.Directory,
+          can_browse: true,
+          can_play: true
+        }),
+        new BrowseMediaItem("radio", "Radio", {
+          media_class: KnownMediaClass.Radio,
+          can_browse: true
+        }),
+        new BrowseMediaItem("albums", "Albums", {
+          media_class: KnownMediaClass.Directory,
+          can_browse: true
+        })
+      ]
+    });
+    return new BrowseResult(root, new uc.Pagination(1, root.items.length, root.items.length));
+  }
+
+  browseFavorites(paging) {
+    const maxFavorites = 99;
+    const items = [];
+    for (let i = paging.offset; i < paging.offset + paging.limit; i++) {
+      const favId = i + 1;
+      if (favId > maxFavorites) {
+        break;
+      }
+      items.push(
+        new BrowseMediaItem(`library://favorite/${favId}`, `Favorite ${favId}`, {
+          media_class: KnownMediaClass.Directory,
+          media_type: KnownMediaContentType.Music,
+          can_play: true
+        })
+      );
+    }
+    const favorites = new BrowseMediaItem("favorites", "Favorites", {
+      media_class: KnownMediaClass.Directory,
+      can_browse: true,
+      can_play: true,
+      items: items
+    });
+    return BrowseResult.fromPaging(favorites, paging, maxFavorites);
+  }
+
+  browseRadio(paging) {
+    const radios = [
+      new BrowseMediaItem("library://radio/1", "RTS Couleur 3", {
+        media_class: KnownMediaClass.Radio,
+        media_type: KnownMediaContentType.Radio,
+        can_play: true
+      }),
+      new BrowseMediaItem("library://radio/3", "Bassdrive", {
+        media_class: KnownMediaClass.Radio,
+        media_type: KnownMediaContentType.Radio,
+        can_play: true
+      }),
+      new BrowseMediaItem("library://radio/4", "BBC Radio 1", {
+        media_class: KnownMediaClass.Radio,
+        media_type: KnownMediaContentType.Radio,
+        can_play: true
+      })
+    ];
+    const items = [];
+    for (let i = paging.offset; i < paging.offset + paging.limit; i++) {
+      if (i < radios.length) {
+        items.push(radios[i]);
+      }
+    }
+
+    const radio = new BrowseMediaItem("radio", "Radio", {
+      media_class: KnownMediaClass.Directory,
+      can_browse: true,
+      items: items
+    });
+    return BrowseResult.fromPaging(radio, paging, 3);
+  }
+
+  browseAlbums(paging) {
+    const maxAlbums = 1234;
+    const items = [];
+    for (let i = paging.offset; i < paging.offset + paging.limit; i++) {
+      const albumId = i + 1;
+      if (albumId > maxAlbums) {
+        break;
+      }
+      items.push(
+        new BrowseMediaItem(`library://album/${albumId}`, `Album ${albumId}`, {
+          media_class: KnownMediaClass.Album,
+          media_type: KnownMediaContentType.Album,
+          can_play: true
+        })
+      );
+    }
+    const albums = new BrowseMediaItem("albums", "Albums", {
+      media_class: KnownMediaClass.Directory,
+      can_browse: true,
+      items: items
+    });
+    return BrowseResult.fromPaging(albums, paging, maxAlbums);
+  }
+}
+
+// add a media-player entity
+const mediaPlayerEntity = new MediaPlayer();
+
+driver.addAvailableEntity(mediaPlayerEntity);

--- a/examples/media-player/media_player.json
+++ b/examples/media-player/media_player.json
@@ -1,0 +1,20 @@
+{
+  "driver_id": "media_player_test",
+  "version": "1.0.0",
+  "min_core_api": "1.0.0",
+  "name": {
+    "en": "Simulated media-player driver",
+    "de": "Simulierter Media-Player Treiber"
+  },
+  "icon": "custom:my_driver_icon",
+  "description": { "en": "A simple demo integration with a simulated media-player entity." },
+  "#driver_url": "OPTIONAL: the remote uses the driver URL from mDNS if `driver_url` is missing, untouched if starting with `ws://` or `wss://`, otherwise dynamically set from determined os hostname and port setting below",
+  "port": "9980",
+  "developer": {
+    "name": "John Doe",
+    "email": "john@doe.com",
+    "url": "https://www.unfoldedcircle.com"
+  },
+  "home_page": "https://www.unfoldedcircle.com",
+  "release_date": "2026-03-13"
+}

--- a/index.ts
+++ b/index.ts
@@ -15,8 +15,10 @@ import { filterBase64Images, getDefaultLanguageString, toLanguageObject } from "
 
 import * as ui from "./lib/entities/ui.js";
 import * as api from "./lib/api_definitions.js";
+import * as msg from "./lib/msg_definitions.js";
 import { Entities } from "./lib/entities/entities.js";
-import { Entity } from "./lib/entities/entity.js";
+import { Entity, EntityType } from "./lib/entities/entity.js";
+import { MediaPlayer } from "./lib/entities/media_player.js";
 
 /**
  * Internal WebSocket handle.
@@ -388,7 +390,7 @@ class IntegrationAPI extends EventEmitter {
           await this.#sendResponse(wsHandle, api.MsgEvents.DeviceState, this.#getDeviceState());
           break;
 
-        case api.Messages.getAvailableEntities:
+        case api.Messages.GetAvailableEntities:
           await this.#sendResponse(wsHandle, api.MsgEvents.AvailableEntities, {
             available_entities: this.#getAvailableEntities()
           });
@@ -427,6 +429,15 @@ class IntegrationAPI extends EventEmitter {
             await this.driverSetupError(wsHandle);
           }
           break;
+
+        case api.Messages.BrowseMedia:
+          await this.#browseMedia(wsHandle, msgData);
+          break;
+
+        case api.Messages.SearchMedia:
+          await this.#searchMedia(wsHandle, msgData);
+          break;
+
         default:
           log.warn(`[${wsId}] Unhandled request: ${msg}`);
           await this.#sendErrorResult(wsHandle);
@@ -697,15 +708,77 @@ class IntegrationAPI extends EventEmitter {
       return;
     }
 
-    if (!entity.hasCmdHandler) {
-      // legacy: emit event, so the driver can act on it
-      log.warn(
-        `DEPRECATED no entity command handler provided for ${data.entity_id} by the driver: please migrate the integration driver, the legacy ENTITY_COMMAND event will be removed in a future release!`
-      );
-      this.emit(api.Events.EntityCommand, wsHandle, data.entity_id, data.entity_type, data.cmd_id, data.params);
+    const result = await entity.command(cmdId, "params" in data ? data.params : undefined);
+    await this.acknowledgeCommand(wsHandle, result);
+  }
+
+  async #browseMedia(wsHandle: WsHandle, data: any) {
+    if (!data) {
+      log.warn("Ignoring browse media: called with empty msg_data");
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);
+      return;
+    }
+
+    const entityId = data.entity_id;
+    if (!entityId) {
+      log.warn("Ignoring browse media: missing entity_id");
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);
+      return;
+    }
+
+    const entity = this.#configuredEntities.getEntity(entityId);
+    if (!entity || entity.entity_type !== EntityType.MediaPlayer || !(entity instanceof MediaPlayer)) {
+      log.warn("Cannot browse media for '%s': no configured entity found or entity is not a media-player", entityId);
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.NotFound);
+      return;
+    }
+
+    const request = data as msg.BrowseMediaMsgData;
+    const paging = api.Paging.fromOptions(request.paging);
+    const result = await entity.browse({ media_id: request.media_id, media_type: request.media_type, paging });
+    if (typeof result === "number") {
+      await this.acknowledgeCommand(wsHandle, result as api.StatusCodes);
     } else {
-      const result = await entity.command(cmdId, "params" in data ? data.params : undefined);
-      await this.acknowledgeCommand(wsHandle, result);
+      await this.#sendResponse(wsHandle, api.MsgEvents.MediaBrowse, result);
+    }
+  }
+
+  async #searchMedia(wsHandle: WsHandle, data: any) {
+    if (!data) {
+      log.warn("Ignoring search media: called with empty msg_data");
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);
+      return;
+    }
+
+    const request = data as msg.SearchMediaMsgData;
+    if (!request || !request.entity_id || !request.query) {
+      log.warn("Ignoring search media: missing entity_id or search_query");
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);
+      return;
+    }
+
+    const entity = this.#configuredEntities.getEntity(request.entity_id);
+    if (!entity || entity.entity_type !== EntityType.MediaPlayer || !(entity instanceof MediaPlayer)) {
+      log.warn(
+        "Cannot search media for '%s': no configured entity found or entity is not a media-player",
+        request.entity_id
+      );
+      await this.acknowledgeCommand(wsHandle, api.StatusCodes.NotFound);
+      return;
+    }
+
+    const paging = api.Paging.fromOptions(request.paging);
+    const result = await entity.search({
+      query: request.query,
+      media_id: request.media_id,
+      media_type: request.media_type,
+      filter: request.filter,
+      paging
+    });
+    if (typeof result === "number") {
+      await this.acknowledgeCommand(wsHandle, result as api.StatusCodes);
+    } else {
+      await this.#sendResponse(wsHandle, api.MsgEvents.MediaSearch, result);
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import * as msg from "./lib/msg_definitions.js";
 import { Entities } from "./lib/entities/entities.js";
 import { Entity, EntityType } from "./lib/entities/entity.js";
 import { MediaPlayer } from "./lib/entities/media_player.js";
+import { BrowseMediaMsgData, SearchMediaMsgData } from "./lib/msg_definitions.js";
 
 /**
  * Internal WebSocket handle.
@@ -431,11 +432,11 @@ class IntegrationAPI extends EventEmitter {
           break;
 
         case api.Messages.BrowseMedia:
-          await this.#browseMedia(wsHandle, msgData);
+          await this.#browseMedia(wsHandle, msgData as BrowseMediaMsgData);
           break;
 
         case api.Messages.SearchMedia:
-          await this.#searchMedia(wsHandle, msgData);
+          await this.#searchMedia(wsHandle, msgData as SearchMediaMsgData);
           break;
 
         default:
@@ -712,7 +713,7 @@ class IntegrationAPI extends EventEmitter {
     await this.acknowledgeCommand(wsHandle, result);
   }
 
-  async #browseMedia(wsHandle: WsHandle, data: any) {
+  async #browseMedia(wsHandle: WsHandle, data: BrowseMediaMsgData) {
     if (!data) {
       log.warn("Ignoring browse media: called with empty msg_data");
       await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);
@@ -743,7 +744,7 @@ class IntegrationAPI extends EventEmitter {
     }
   }
 
-  async #searchMedia(wsHandle: WsHandle, data: any) {
+  async #searchMedia(wsHandle: WsHandle, data: SearchMediaMsgData) {
     if (!data) {
       log.warn("Ignoring search media: called with empty msg_data");
       await this.acknowledgeCommand(wsHandle, api.StatusCodes.BadRequest);

--- a/lib/api_definitions.ts
+++ b/lib/api_definitions.ts
@@ -32,14 +32,16 @@ export enum Messages {
   Authentication = "authentication",
   GetDriverVersion = "get_driver_version",
   GetDeviceState = "get_device_state",
-  getAvailableEntities = "get_available_entities",
+  GetAvailableEntities = "get_available_entities",
   GetEntityStates = "get_entity_states",
   SubscribeEvents = "subscribe_events",
   UnsubscribeEvents = "unsubscribe_events",
   EntityCommand = "entity_command",
   GetDriverMetadata = "get_driver_metadata",
   SetupDriver = "setup_driver",
-  SetDriverUserData = "set_driver_user_data"
+  SetDriverUserData = "set_driver_user_data",
+  BrowseMedia = "browse_media",
+  SearchMedia = "search_media"
 }
 
 // Define event messages
@@ -54,6 +56,8 @@ export enum MsgEvents {
   EntityStates = "entity_states",
   EntityChange = "entity_change",
   DriverMetadata = "driver_metadata",
+  MediaBrowse = "media_browse",
+  MediaSearch = "media_search",
   DriverSetupChange = "driver_setup_change",
   AbortDriverSetup = "abort_driver_setup",
   GenerateOauth2AuthUrl = "generate_oauth2_auth_url",
@@ -67,7 +71,6 @@ export enum MsgEvents {
 }
 
 export enum Events {
-  EntityCommand = "entity_command",
   EntityAttributesUpdated = "entity_attributes_updated",
   SubscribeEntities = "subscribe_entities",
   UnsubscribeEntities = "unsubscribe_entities",
@@ -277,4 +280,110 @@ export interface Oauth2Token {
   refresh_token?: string;
   expires_in?: number;
   token_type?: string;
+}
+
+/**
+ * Raw, unvalidated paging input — e.g. from a parsed query string or request body.
+ */
+export interface PagingOptions {
+  /**
+   * Page number, 1-based.
+   */
+  page?: number;
+
+  /**
+   * Number of items returned per page.
+   */
+  limit?: number;
+}
+
+/**
+ * Paging query parameters.
+ *
+ * All parameters are optional; defaults are applied if omitted.
+ * Validates input on construction — throws RangeError on invalid values.
+ */
+export class Paging {
+  private readonly _page: number | undefined;
+  private readonly _limit: number | undefined;
+
+  static readonly DEFAULT_PAGE = 1;
+  static readonly DEFAULT_LIMIT = 10;
+  static readonly MAX_LIMIT = 100;
+
+  /**
+   * @param page  Page number, 1-based. Defaults to 1 if omitted.
+   * @param limit Number of items per page. Max 100. Defaults to 10 if omitted.
+   * @throws {RangeError} if page < 1 or limit is outside [1, 100].
+   */
+  constructor(page?: number, limit?: number) {
+    if (page !== undefined && (page < 1 || !Number.isInteger(page))) {
+      throw new RangeError(`Invalid page number: ${page}. Must be an integer >= 1.`);
+    }
+    if (limit !== undefined && (limit < 1 || limit > Paging.MAX_LIMIT || !Number.isInteger(limit))) {
+      throw new RangeError(`Invalid limit: ${limit}. Must be an integer between 1 and ${Paging.MAX_LIMIT}.`);
+    }
+    this._page = page;
+    this._limit = limit;
+  }
+
+  /** Page number, 1-based. */
+  get page(): number {
+    return this._page ?? Paging.DEFAULT_PAGE;
+  }
+
+  /** Number of items per page. */
+  get limit(): number {
+    return this._limit ?? Paging.DEFAULT_LIMIT;
+  }
+
+  /** Overall item start offset, 0-based. */
+  get offset(): number {
+    return this.limit * (this.page - 1);
+  }
+
+  /** Returns a default Paging instance (page=1, limit=10). */
+  static default(): Paging {
+    return new Paging();
+  }
+
+  /** Construct from a raw, unvalidated options object (e.g. from a request body). */
+  static fromOptions(options: PagingOptions = {}): Paging {
+    return new Paging(options.page, options.limit);
+  }
+}
+
+/**
+ * Pagination metadata returned by the client.
+ */
+export class Pagination {
+  readonly page: number;
+  readonly limit: number;
+  readonly total?: number;
+
+  /**
+   * @param page  Current page number, 1-based. Must correspond to the requested page.
+   * @param limit Number of items returned in this page (1–100).
+   * @param total Optional if known: Total number of available items across all pages.
+   * @throws {RangeError} if any parameter violates its constraints.
+   */
+  constructor(page: number, limit: number, total?: number) {
+    if (!Number.isInteger(page) || page < 1) {
+      throw new RangeError(`Pagination: page must be an integer >= 1, got ${page}`);
+    }
+    if (!Number.isInteger(limit) || limit < 0 || limit > 100) {
+      throw new RangeError(`Pagination: limit must be an integer between 0 and 100, got ${limit}`);
+    }
+    if (total && (!Number.isInteger(total) || total < 0)) {
+      throw new RangeError(`Pagination: total must be a non-negative integer, got ${total}`);
+    }
+
+    this.page = page;
+    this.limit = limit;
+    this.total = total;
+  }
+
+  static empty(): Pagination {
+    return new Pagination(1, 0, 0);
+  }
 }

--- a/lib/api_definitions.ts
+++ b/lib/api_definitions.ts
@@ -386,4 +386,8 @@ export class Pagination {
   static empty(): Pagination {
     return new Pagination(1, 0, 0);
   }
+
+  static fromPaging(paging: Paging, total?: number): Pagination {
+    return new Pagination(paging.page, paging.limit, total);
+  }
 }

--- a/lib/entities/entities.ts
+++ b/lib/entities/entities.ts
@@ -6,7 +6,7 @@
  */
 
 import { EventEmitter } from "events";
-import { Entity } from "./entity.js";
+import { Entity, EntityAttributes } from "./entity.js";
 import { Events } from "../api_definitions.js";
 import log from "../loggers.js";
 
@@ -60,7 +60,7 @@ export class Entities extends EventEmitter {
    * @param {Record<string, any>} attributes The attributes to merge into the entity's attributes
    * @returns {boolean} false if entity doesn't exist, true if attributes were merged.
    */
-  updateEntityAttributes(id: string, attributes: { [key: string]: string | number | boolean }): boolean {
+  updateEntityAttributes(id: string, attributes: EntityAttributes): boolean {
     if (!this.contains(id)) {
       return false;
     }

--- a/lib/entities/entity.ts
+++ b/lib/entities/entity.ts
@@ -26,18 +26,17 @@ export enum EntityType {
 }
 
 export type EntityName = string | { [key: string]: string };
+export type EntityAttributes = { [key: string]: string | number | boolean | string[] };
+export type EntityOptions = { [key: string]: string | number | boolean | object };
+export type EntityCommandParams = { [key: string]: string | number | boolean };
 
-export type CommandHandler = (
-  entity: Entity,
-  command: string,
-  params?: { [key: string]: string | number | boolean }
-) => Promise<StatusCodes>;
+export type CommandHandler = (entity: Entity, command: string, params?: EntityCommandParams) => Promise<StatusCodes>;
 
 export interface EntityParams {
   features?: string[];
-  attributes?: { [key: string]: string | string[] | number | boolean };
+  attributes?: EntityAttributes;
   deviceClass?: string;
-  options?: { [key: string]: string | number | boolean | object };
+  options?: EntityOptions;
   area?: string;
   cmdHandler?: CommandHandler;
 }
@@ -50,9 +49,9 @@ export class Entity {
   public device_id?: string;
 
   public features?: string[];
-  public attributes?: { [key: string]: string | string[] | number | boolean };
+  public attributes?: EntityAttributes;
   public device_class?: string;
-  public options?: { [key: string]: string | number | boolean | object };
+  public options?: EntityOptions;
   public area?: string;
   #cmdHandler?: CommandHandler;
 
@@ -108,7 +107,7 @@ export class Entity {
    * @param params optional command parameters
    * @return command status code to acknowledge to UC Remote
    */
-  async command(cmdId: string, params?: { [key: string]: string | number | boolean }): Promise<StatusCodes> {
+  async command(cmdId: string, params?: EntityCommandParams): Promise<StatusCodes> {
     if (this.#cmdHandler) {
       return await this.#cmdHandler(this, cmdId, params);
     }

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -607,7 +607,7 @@ export class MediaPlayer extends Entity {
    * @return {Promise<StatusCodes | BrowseResult>} command status code in case of an error, otherwise the browse result.
    */
   async browse(options: BrowseOptions): Promise<StatusCodes | BrowseResult> {
-    log.warn("Media browsing not supported for %s", this.id);
+    log.warn("Media browsing not supported for %s. Request: %s", this.id, JSON.stringify(options));
 
     return StatusCodes.NotImplemented;
   }
@@ -621,7 +621,7 @@ export class MediaPlayer extends Entity {
    * @return {Promise<StatusCodes | BrowseResult>} command status code in case of an error, otherwise the search result.
    */
   async search(query: SearchOptions): Promise<StatusCodes | SearchResult> {
-    log.warn("Media searching not supported for %s", this.id);
+    log.warn("Media searching not supported for %s. Request: %s", this.id, JSON.stringify(query));
 
     return StatusCodes.NotImplemented;
   }

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -122,7 +122,8 @@ export enum MediaPlayerAttributes {
   SourceList = "source_list",
   SoundMode = "sound_mode",
   SoundModeList = "sound_mode_list",
-  SearchMediaClasses = "search_media_classes"
+  SearchMediaClasses = "search_media_classes",
+  PlayMediaAction = "play_media_action"
 }
 
 /**
@@ -369,6 +370,11 @@ export interface SearchMediaFilter {
  */
 export interface BrowseMediaItemOptions {
   /**
+   * Optional subtitle.
+   */
+  subtitle?: string;
+
+  /**
    * Artist name.
    */
   artist?: string;
@@ -432,6 +438,7 @@ export interface BrowseMediaItemOptions {
 export class BrowseMediaItem {
   readonly media_id: string;
   readonly title: string;
+  readonly subtitle?: string;
   readonly artist?: string;
   readonly album?: string;
   readonly media_class?: MediaClass;
@@ -461,6 +468,7 @@ export class BrowseMediaItem {
     this.title = title;
 
     // Spread optional fields explicitly to avoid leaking unexpected properties
+    this.subtitle = options.subtitle;
     this.artist = options.artist;
     this.album = options.album;
     this.media_class = options.media_class;
@@ -546,13 +554,18 @@ export class SearchResult {
 }
 
 /**
- * Media play actions.
+ * Pre-defined media play actions with UI support.
  */
-export enum MediaPlayAction {
+export enum KnownMediaPlayAction {
   PlayNow = "PLAY_NOW",
   PlayNext = "PLAY_NEXT",
   AddToQueue = "ADD_TO_QUEUE"
 }
+
+/**
+ * Media play action type definition of all known actions, plus custom-defined actions.
+ */
+export type MediaPlayAction = KnownMediaPlayAction | (string & {});
 
 /**
  * Repeat modes.

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -8,6 +8,7 @@
 
 import { Entity, EntityType, CommandHandler, EntityName } from "./entity.js";
 import log from "../loggers.js";
+import { Pagination, Paging, StatusCodes } from "../api_definitions.js";
 
 /**
  * Media-player entity states.
@@ -50,23 +51,52 @@ export enum MediaPlayerFeatures {
   MediaAlbum = "media_album",
   MediaImageUrl = "media_image_url",
   MediaType = "media_type",
+  /** Directional pad navigation provides cursor_up, _down, _left, _right, _enter commands. */
   Dpad = "dpad",
+  /** Number pad, provides digit_0 .. digit_9 commands. */
   Numpad = "numpad",
+  /** Home navigation support with home and back commands. */
   Home = "home",
+  /** Menu navigation support with menu and back commands. */
   Menu = "menu",
+  /** Context menu (for example, right-clicking or long pressing an item). */
   ContextMenu = "context_menu",
+  /** Program guide support with guide and back commands. */
   Guide = "guide",
+  /** Information popup / menu support with info and back commands. */
   Info = "info",
+  /** Color button support for function_red, _green, _yellow, _blue commands. */
   ColorButtons = "color_buttons",
+  /** Channel zapping support with channel_up and _down commands. */
   ChannelSwitcher = "channel_switcher",
+  /** Media playback sources or inputs can be selected. */
   SelectSource = "select_source",
+  /** Sound modes can be selected, e.g., stereo or surround. */
   SelectSoundMode = "select_sound_mode",
+  /** The media can be ejected, e.g., a slot-in CD or USB stick. */
   Eject = "eject",
+  /** The player supports opening and closing, e.g., a disc tray. */
   OpenClose = "open_close",
+  /** The player supports selecting or switching the audio track. */
   AudioTrack = "audio_track",
+  /** The player supports selecting or switching subtitles. */
   Subtitle = "subtitle",
+  /** The player has recording capabilities with record, my_recordings, live commands. */
   Record = "record",
-  Settings = "settings"
+  /** The player supports a settings menu. */
+  Settings = "settings",
+  /** The player supports playing a specific media item. */
+  PlayMedia = "play_media",
+  /** The player supports the play_media action parameter to either play or enqueue. */
+  PlayMediaAction = "play_media_action",
+  /** The player allows clearing the active playlist. */
+  ClearPlaylist = "clear_playlist",
+  /** The player supports browsing media containers. */
+  BrowseMedia = "browse_media",
+  /** The player supports searching for media items. */
+  SearchMedia = "search_media",
+  /** The player provides a list of media classes as filter for searches. */
+  SearchMediaClasses = "search_media_classes"
 }
 
 /**
@@ -79,17 +109,20 @@ export enum MediaPlayerAttributes {
   MediaDuration = "media_duration",
   MediaPosition = "media_position",
   MediaPositionUpdatedAt = "media_position_updated_at",
-  MediaType = "media_type",
   MediaImageUrl = "media_image_url",
+  MediaPlaylist = "media_playlist",
   MediaTitle = "media_title",
   MediaArtist = "media_artist",
   MediaAlbum = "media_album",
+  MediaId = "media_id",
+  MediaType = "media_type",
   Repeat = "repeat",
   Shuffle = "shuffle",
   Source = "source",
   SourceList = "source_list",
   SoundMode = "sound_mode",
-  SoundModeList = "sound_mode_list"
+  SoundModeList = "sound_mode_list",
+  SearchMediaClasses = "search_media_classes"
 }
 
 /**
@@ -116,10 +149,15 @@ export enum MediaPlayerCommands {
   Shuffle = "shuffle",
   ChannelUp = "channel_up",
   ChannelDown = "channel_down",
+  /** Directional pad up */
   CursorUp = "cursor_up",
+  /** Directional pad down */
   CursorDown = "cursor_down",
+  /** Directional pad left */
   CursorLeft = "cursor_left",
+  /** Directional pad right */
   CursorRight = "cursor_right",
+  /** Directional pad enter */
   CursorEnter = "cursor_enter",
   Digit0 = "digit_0",
   Digit1 = "digit_1",
@@ -135,25 +173,43 @@ export enum MediaPlayerCommands {
   FunctionGreen = "function_green",
   FunctionYellow = "function_yellow",
   FunctionBlue = "function_blue",
+  /** Home menu */
   Home = "home",
+  /** General menu */
   Menu = "menu",
+  /** Context menu */
   ContextMenu = "context_menu",
+  /** Program guide menu. */
   Guide = "guide",
+  /** Information menu / what's playing. */
   Info = "info",
+  /** Back / exit function for menu navigation. */
   Back = "back",
+  /** Select media playback source or input from the available sources. */
   SelectSource = "select_source",
+  /** Select a sound mode from the available modes. */
   SelectSoundMode = "select_sound_mode",
+  /** Start, stop or open recording menu (device dependant). */
   Record = "record",
+  /** Open recordings. */
   MyRecordings = "my_recordings",
+  /** Switch to live view. */
   Live = "live",
+  /** Eject media. */
   Eject = "eject",
+  /** Open or close. */
   OpenClose = "open_close",
+  /** Switch or select audio track. */
   AudioTrack = "audio_track",
+  /** Switch or select subtitle. */
   Subtitle = "subtitle",
+  /** Settings menu */
   Settings = "settings",
-  Search = "search"
+  /** Play or enqueue a media item. */
+  PlayMedia = "play_media",
+  /** Remove all items from the playback queue. Current playback behavior is integration-dependent (keep playing the current item or clearing everything). */
+  ClearPlaylist = "clear_playlist"
 }
-
 /**
  * Media-player entity device classes.
  */
@@ -174,14 +230,328 @@ export enum MediaPlayerOptions {
 }
 
 /**
- * Media types.
+ * Pre-defined media content types.
  */
-export enum MediaType {
-  Music = "MUSIC",
-  Radio = "RADIO",
-  TVShow = "TVSHOW",
-  Movie = "MOVIE",
-  Video = "VIDEO"
+export enum KnownMediaContentType {
+  Album = "album",
+  App = "app",
+  Apps = "apps",
+  Artist = "artist",
+  Channel = "channel",
+  Channels = "channels",
+  Composer = "composer",
+  Episode = "episode",
+  Game = "game",
+  Genre = "genre",
+  Image = "image",
+  Movie = "movie",
+  Music = "music",
+  Playlist = "playlist",
+  Podcast = "podcast",
+  Radio = "radio",
+  Season = "season",
+  Track = "track",
+  TvShow = "tv_show",
+  Url = "url",
+  Video = "video"
+}
+
+/**
+ * Media content type definition of all known media types, plus custom-defined types.
+ */
+export type MediaContentType = KnownMediaContentType | (string & {});
+// `(string & {})`: “This is still any string, but please don’t eagerly reduce the whole union to plain string.”
+// This helps editors offer autocomplete for the known values.
+
+/**
+ * Pre-defined media classes.
+ */
+export enum KnownMediaClass {
+  Album = "album",
+  App = "app",
+  Artist = "artist",
+  Channel = "channel",
+  Composer = "composer",
+  Directory = "directory",
+  Episode = "episode",
+  Game = "game",
+  Genre = "genre",
+  Image = "image",
+  Movie = "movie",
+  Music = "music",
+  Playlist = "playlist",
+  Podcast = "podcast",
+  Radio = "radio",
+  Season = "season",
+  Track = "track",
+  TvShow = "tv_show",
+  Url = "url",
+  Video = "video"
+}
+
+/**
+ * Media item class type definition of all known class types, plus custom-defined types.
+ */
+export type MediaClass = KnownMediaClass | (string & {});
+
+/**
+ * Media browse options for the media browse client callback.
+ */
+export interface BrowseOptions {
+  /**
+   * Optional media content ID to restrict browsing.
+   */
+  media_id?: string;
+
+  /**
+   * Optional media content type to restrict browsing.
+   */
+  media_type?: MediaContentType;
+
+  /**
+   * Paging options to limit returned items.
+   */
+  paging: Paging;
+}
+
+/**
+ * Media search options for the media search client callback.
+ */
+export interface SearchOptions {
+  /**
+   * Free text search query.
+   */
+  query: string;
+
+  /**
+   * Optional media content ID to limit the search scope. E.g., in a previously browsed media item.
+   */
+  media_id?: string;
+
+  /**
+   * Optional media content type to limit the search scope. E.g., in a previously browsed media item.
+   */
+  media_type?: MediaContentType;
+
+  /**
+   * Additional user filter to limit the search scope.
+   */
+  filter?: SearchMediaFilter;
+
+  /**
+   * Paging options to limit returned items.
+   */
+  paging: Paging;
+}
+
+/**
+ * Filter for media search.
+ */
+export interface SearchMediaFilter {
+  /**
+   * Optional list of media classes to filter the results.
+   */
+  media_classes?: MediaClass[];
+
+  /**
+   * TBD not yet finalized
+   */
+  artist?: string;
+
+  /**
+   * TBD not yet finalized
+   */
+  album?: string;
+}
+
+/**
+ * Optional fields for constructing a BrowseMediaItem.
+ */
+export interface BrowseMediaItemOptions {
+  /**
+   * Artist name.
+   */
+  artist?: string;
+
+  /**
+   * Album name.
+   */
+  album?: string;
+
+  /**
+   * Media class for further browse, search, or playback actions.
+   */
+  media_class?: MediaClass;
+
+  /**
+   * Media content type for further browse, search, or playback actions.
+   */
+  media_type?: MediaContentType;
+
+  /**
+   * If `true`, the item can be browsed (is a container) by using `media_id` and `media_type`.
+   */
+  can_browse?: boolean;
+
+  /**
+   * If `true`, the item can be played directly by using `media_id` and `media_type`.
+   */
+  can_play?: boolean;
+
+  /**
+   * If `true`, a search can be performed on the item by using `media_id` and `media_type`.
+   */
+  can_search?: boolean;
+
+  /**
+   * URL to download the media artwork, or a base64 encoded PNG or JPG image.
+   *
+   * Use the following URI prefix to use a provided icon: `icon://uc:`, for example, `icon://uc:music`.
+   * Please avoid using encoded images whenever possible. Payloads should be as small as possible.
+   */
+  thumbnail?: string;
+
+  /**
+   * Duration in seconds.
+   */
+  duration?: number;
+
+  /**
+   * Child items if this item is a container.
+   * Child items may not contain further child items (only one level of nesting is supported).
+   * A new browse request must be sent for deeper levels.
+   */
+  items?: BrowseMediaItem[];
+}
+
+/**
+ * A media item which can be browsed or played.
+ *
+ * Created by the client and returned to the library in response to a browse or search request.
+ */
+export class BrowseMediaItem {
+  readonly media_id: string;
+  readonly title: string;
+  readonly artist?: string;
+  readonly album?: string;
+  readonly media_class?: MediaClass;
+  readonly media_type?: MediaContentType;
+  readonly can_browse?: boolean;
+  readonly can_play?: boolean;
+  readonly can_search?: boolean;
+  readonly thumbnail?: string;
+  readonly duration?: number;
+  readonly items?: BrowseMediaItem[];
+
+  /**
+   * @param media_id Unique identifier of the item.
+   * @param title    Display name (must be a non-empty string).
+   * @param options  Optional metadata fields.
+   * @throws {TypeError} if media_id or title are missing or not strings.
+   */
+  constructor(media_id: string, title: string, options: BrowseMediaItemOptions = {}) {
+    if (typeof media_id !== "string") {
+      throw new TypeError("BrowseMediaItem: media_id must be a non-empty string");
+    }
+    if (!title || typeof title !== "string") {
+      throw new TypeError("BrowseMediaItem: title must be a non-empty string");
+    }
+
+    this.media_id = media_id;
+    this.title = title;
+
+    // Spread optional fields explicitly to avoid leaking unexpected properties
+    this.artist = options.artist;
+    this.album = options.album;
+    this.media_class = options.media_class;
+    this.media_type = options.media_type;
+    this.can_browse = options.can_browse;
+    this.can_play = options.can_play;
+    this.can_search = options.can_search;
+    this.thumbnail = options.thumbnail;
+    this.duration = options.duration;
+    this.items = options.items;
+  }
+}
+
+/**
+ * A media item returned as a search result.
+ *
+ * Currently identical in shape to {@link BrowseMediaItem}.
+ * Defined as a subclass to allow search-specific fields (e.g. relevance score) to be added
+ * in the future without a breaking change.
+ */
+export class SearchMediaItem extends BrowseMediaItem {}
+
+/**
+ * Response to a browse request.
+ *
+ * Created by the client and returned to the library in response to a browse request.
+ */
+export class BrowseResult {
+  readonly media: BrowseMediaItem | undefined;
+  readonly pagination: Pagination;
+
+  /**
+   * @param media      The browsed media item, or `undefined` if not found.
+   * @param pagination Pagination metadata for this result page.
+   * @throws {TypeError} if media is not a BrowseMediaItem instance or pagination is not a Pagination instance.
+   */
+  constructor(media: BrowseMediaItem | undefined, pagination: Pagination) {
+    if (!(pagination instanceof Pagination)) {
+      throw new TypeError("BrowseResult: pagination must be an instance of Pagination");
+    }
+    if (media !== undefined && !(media instanceof BrowseMediaItem)) {
+      throw new TypeError("BrowseResult: media must be an instance of BrowseMediaItem or undefined");
+    }
+
+    this.media = media;
+    this.pagination = pagination;
+  }
+
+  static empty(): BrowseResult {
+    return new BrowseResult(undefined, Pagination.empty());
+  }
+
+  static fromPaging(media: BrowseMediaItem, paging: Paging, total?: number): BrowseResult {
+    return new BrowseResult(media, new Pagination(paging.page, media.items?.length || 0, total));
+  }
+}
+
+/**
+ * Response to a search request.
+ *
+ * Created by the client and returned to the library in response to a search request.
+ */
+export class SearchResult {
+  readonly media: SearchMediaItem[];
+  readonly pagination: Pagination;
+
+  /**
+   * @param media      Array of matching media items. Pass an empty array if no results were found.
+   * @param pagination Pagination metadata for this result page.
+   * @throws {TypeError} if media is not an array or pagination is not a Pagination instance.
+   */
+  constructor(media: SearchMediaItem[], pagination: Pagination) {
+    if (!Array.isArray(media)) {
+      throw new TypeError("SearchResult: media must be an array");
+    }
+    if (!(pagination instanceof Pagination)) {
+      throw new TypeError("SearchResult: pagination must be an instance of Pagination");
+    }
+
+    this.media = media;
+    this.pagination = pagination;
+  }
+}
+
+/**
+ * Media play actions.
+ */
+export enum MediaPlayAction {
+  PlayNow = "PLAY_NOW",
+  PlayNext = "PLAY_NEXT",
+  AddToQueue = "ADD_TO_QUEUE"
 }
 
 /**
@@ -192,8 +562,6 @@ export enum RepeatMode {
   All = "ALL",
   One = "ONE"
 }
-
-//export type CmdHandler = (entity: Entity, command: string, options?: Record<string, unknown>) => Promise<string>;
 
 export interface MediaPlayerParams {
   features?: MediaPlayerFeatures[];
@@ -210,13 +578,12 @@ export interface MediaPlayerParams {
  * See {@link https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_media_player.md media-player entity documentation}
  * for more information.
  */
-
 export class MediaPlayer extends Entity {
   /**
    * Constructs a new media-player entity.
    *
    * @param {string} id The entity identifier. Must be unique inside the integration driver.
-   * @param name The human-readable name of the entity.
+   * @param {EntityName} name The human-readable name of the entity.
    *        Either a string, which will be mapped to English, or a Map / Object containing multiple language strings.
    * @param {MediaPlayerParams} [params] Entity parameters.
    * @throws AssertionError if invalid parameters are specified.
@@ -229,5 +596,33 @@ export class MediaPlayer extends Entity {
     super(id, name, EntityType.MediaPlayer, { features, attributes, deviceClass, options, area, cmdHandler });
 
     log.debug(`MediaPlayer entity created with id: ${this.id}`);
+  }
+
+  /**
+   * Default browse media item handler. Returns status code `NotImplemented`.
+   *
+   * A client needs to add the `BrowseMedia` feature and override this method if it wants to handle browse requests.
+   *
+   * @param {BrowseOptions} options the browse options.
+   * @return {Promise<StatusCodes | BrowseResult>} command status code in case of an error, otherwise the browse result.
+   */
+  async browse(options: BrowseOptions): Promise<StatusCodes | BrowseResult> {
+    log.warn("Media browsing not supported for %s", this.id);
+
+    return StatusCodes.NotImplemented;
+  }
+
+  /**
+   * Default search media item handler. Returns status code `NotImplemented`.
+   *
+   * A client needs to add the `SearchMedia` feature and override this method if it wants to handle search requests.
+   *
+   * @param {SearchOptions} query the search query options.
+   * @return {Promise<StatusCodes | BrowseResult>} command status code in case of an error, otherwise the search result.
+   */
+  async search(query: SearchOptions): Promise<StatusCodes | SearchResult> {
+    log.warn("Media searching not supported for %s", this.id);
+
+    return StatusCodes.NotImplemented;
   }
 }

--- a/lib/entities/remote.ts
+++ b/lib/entities/remote.ts
@@ -6,7 +6,7 @@
  * @license Apache License 2.0, see LICENSE for more details.
  */
 
-import { CommandHandler, Entity, EntityType, EntityName } from "./entity.js";
+import { CommandHandler, Entity, EntityType, EntityName, EntityOptions } from "./entity.js";
 import { DeviceButtonMapping, EntityCommand, UiPage } from "./ui.js";
 import log from "../loggers.js";
 import assert from "node:assert";
@@ -140,7 +140,7 @@ export class Remote extends Entity {
     name: EntityName,
     { features, attributes, simpleCommands, buttonMapping, uiPages, area, cmdHandler }: RemoteParams = {}
   ) {
-    const options: { [key: string]: string | number | boolean | object } = {};
+    const options: EntityOptions = {};
     if (simpleCommands) {
       options[RemoteOptions.SimpleCommands] = simpleCommands;
     }

--- a/lib/msg_definitions.ts
+++ b/lib/msg_definitions.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration driver API WS message definitions for Unfolded Circle Remote devices.
+ *
+ * @copyright (c) 2026 by Unfolded Circle ApS.
+ * @license Apache License 2.0, see LICENSE for more details.
+ */
+
+import { BrowseMediaItem, MediaContentType, SearchMediaFilter, SearchMediaItem } from "./entities/media_player";
+import { Pagination, PagingOptions } from "./api_definitions";
+
+/**
+ * Payload data of `browse_media` request message in `msg_data` property.
+ */
+export interface BrowseMediaMsgData {
+  /**
+   * media-player entity ID to browse.
+   */
+  entity_id: string;
+
+  /**
+   * Optional media content ID to restrict browsing.
+   */
+  media_id?: string;
+
+  /**
+   * Optional media content type to restrict browsing.
+   */
+  media_type?: MediaContentType;
+
+  /**
+   * Optional paging object to limit returned items.
+   */
+  paging?: PagingOptions;
+}
+
+/**
+ * Payload data of `search_media` request message in `msg_data` property.
+ *
+ * Search for media items in a media-player entity.
+ */
+export interface SearchMediaMsgData {
+  /**
+   * media-player entity ID to search in.
+   */
+  entity_id: string;
+
+  /**
+   * Free text search query.
+   */
+  query: string;
+
+  /**
+   * Optional media content ID to limit the search scope. E.g., in a previously browsed media item.
+   */
+  media_id?: string;
+
+  /**
+   * Optional media content type to limit the search scope. E.g., in a previously browsed media item.
+   */
+  media_type?: MediaContentType;
+
+  /**
+   * Additional user filter to limit the search scope.
+   */
+  filter?: SearchMediaFilter;
+
+  /**
+   * Optional paging object to limit returned items.
+   */
+  paging?: PagingOptions;
+}
+
+/**
+ * Media browse response payload in the `msg_data` property.
+ */
+export interface BrowseMediaResponseMsgData {
+  /**
+   * Media browse result. Absent if no item was found.
+   */
+  media?: BrowseMediaItem;
+
+  /**
+   * Pagination information for this result page.
+   */
+  pagination: Pagination;
+}
+
+/**
+ * Media search response payload in the `msg_data` property.
+ */
+export interface SearchMediaResponseMsgData {
+  /**
+   * Media search results.
+   */
+  media: SearchMediaItem[];
+
+  /**
+   * Pagination information for this result page.
+   */
+  pagination: Pagination;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --write .",
     "code-check": "prettier --check . && eslint .",
     "lint": "eslint --fix",
-    "test": "npx tsc && ava dist/test/**/*.js",
+    "test": "npx tsc && ava dist/test/**/*.test.js",
     "build": "npm run build:cjs && npm run build:mjs",
     "build:mjs": "tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",
     "build:cjs": "tsc --project tsconfig.cjs.json && cp res/package.cjs.json dist/cjs/package.json",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "build:cjs": "tsc --project tsconfig.cjs.json && cp res/package.cjs.json dist/cjs/package.json",
     "build:win": "npm run build:cjs-win && npm run build:mjs-win",
     "build:mjs-win": "tsc --project tsconfig.mjs.json && xcopy .\\res\\package.mjs.json .\\dist\\mjs\\package.json /-I /Y",
-    "build:cjs-win": "tsc --project tsconfig.cjs.json && xcopy .\\res\\package.cjs.json .\\dist\\cjs\\package.json /-I /Y"
+    "build:cjs-win": "tsc --project tsconfig.cjs.json && xcopy .\\res\\package.cjs.json .\\dist\\cjs\\package.json /-I /Y",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add a new media player example with browsing and searching capabilities.

BREAKING CHANGE: remove legacy `EntityCommand` event. This allows overriding entity classes and redefining the command handler. Also the MediaPlayer entity class defines new command handlers for the `browse` and `search` operations.

BREAKING CHANGE: fix case in `Messages.getAvailableEntities` enum. Enum is now `GetAvailableEntities`.

Relates to https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/70