### PR TITLE
feat: add media-player stable_id_support option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+
+- media-player stable_id_support option.
+
 ### Changed
 
 - Update entity documentation ([#61](https://github.com/unfoldedcircle/integration-node-library/pull/61)).

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -360,7 +360,6 @@ export const StableIdSupport = {
   SearchSupportsStableIdsParam: 1 << 3
 } as const;
 
-export type StableIdSupportMask = number;
 /**
  * Pre-defined media content types.
  *

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -336,7 +336,18 @@ export enum MediaPlayerOptions {
   /** Additional commands the media-player supports, which are not covered in the feature list. */
   SimpleCommands = "simple_commands",
   /** Number of available volume steps for the set volume command and UI controls. */
-  VolumeSteps = "volume_steps"
+  VolumeSteps = "volume_steps",
+  /**
+   * Bit-field indicating if the `browse` and `search` commands support stable media IDs:
+   *
+   * - Bit 0: `browse` always returns stable ids.
+   * - Bit 1: `browse` supports stable ids with the `stable_ids` parameter.
+   * - Bit 2: `search` always returns stable ids.
+   * - Bit 3: `search` returns stable ids with the `stable_ids` parameter.
+   *
+   * Default if not provided: `browse` and `search` always return stable IDs (Bit 0 | Bit 2)
+   */
+  StableIdSupport = "stable_id_support"
 }
 
 /**

--- a/lib/entities/media_player.ts
+++ b/lib/entities/media_player.ts
@@ -351,6 +351,17 @@ export enum MediaPlayerOptions {
 }
 
 /**
+ * Bit-field indicating if the `browse` and `search` commands support stable media IDs.
+ */
+export const StableIdSupport = {
+  BrowseAlwaysStableIds: 1 << 0,
+  BrowseSupportsStableIdsParam: 1 << 1,
+  SearchAlwaysStableIds: 1 << 2,
+  SearchSupportsStableIdsParam: 1 << 3
+} as const;
+
+export type StableIdSupportMask = number;
+/**
  * Pre-defined media content types.
  *
  * The media content type is for playback/content semantics.


### PR DESCRIPTION
Bit-field indicating if the `browse` and `search` commands support stable media IDs:

- Bit 0: `browse` always returns stable ids.
- Bit 1: `browse` supports stable ids with the `stable_ids` parameter.
- Bit 2: `search` always returns stable ids.
- Bit 3: `search` returns stable ids with the `stable_ids` parameter.

Default if not provided: `browse` and `search` always return stable IDs (Bit 0 | Bit 2)

Refers to unfoldedcircle/core-api#80